### PR TITLE
Remove direct dependency on internal artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: cpp
 dist: bionic
 
-compiler:
-  - gcc
-  - clang
-
 addons:
   apt:
     sources: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ env:
 script:
   - bazel-3.5.0 build --config asan spectator_test spectatord_test spectatord_main
   - bazel-bin/spectator_test && bazel-bin/spectatord_test
+
+cache:
+  directories:
+  - $HOME/.cache/bazel

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
+config_setting(
+    name = "nflx_internal",
+    define_values = {
+        "nflx_internal": "1"
+        }
+    )
+
 memory_allocator = select({
     "@bazel_tools//src/conditions:linux_x86_64": "@com_google_tcmalloc//tcmalloc",
     "//conditions:default": "@bazel_tools//tools/cpp:malloc", 
@@ -47,6 +54,13 @@ cc_library(
         ],
     visibility = ["//visibility:public"])
 
+cc_library(
+    name = "dummy_cfg",
+    srcs = ["spectator/sample_config.cc"],
+    deps = [":spectator"],
+    visibility = ["//visibility:public"])
+
+
 cc_binary(
     name = "gen_perc_bucket_tags",
     srcs = ["tools/gen_perc_bucket_tags.cc"],
@@ -91,10 +105,11 @@ genrule(
 
 cc_test(
     name = "spectator_test",
-    srcs = glob(["spectator/*test.cc", "spectator/sample_config.cc",
+    srcs = glob(["spectator/*test.cc", 
                  "spectator/http_server.*", "spectator/test_utils.*"]),
     deps = [
         ":spectator",
+        ":dummy_cfg",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -200,11 +215,12 @@ cc_binary(
     includes = ["server"],
     deps = [
         ":spectatord",
-        "@spectator_cfg//:spectator_cfg",
         "@com_google_absl//absl/flags:parse",
         "@com_github_gabime_spdlog//:spdlog",
-        "@com_github_bombela_backward//:backward",
-    ],
+        "@com_github_bombela_backward//:backward",] + select({
+        ":nflx_internal": [ "@nflx_spectator_cfg//:spectator_cfg" ],
+        "//conditions:default": [":dummy_cfg"],
+        })
 )
 
 cc_binary(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spectatord - A High Performance Metrics Daemon
 
-[![Build Status](https://travis-ci.com/Netflix-Skunkworks/atlas-system-agent.svg?branch=master)](https://travis-ci.com/Netflix-Skunkworks/atlas-system-agent)
+[![Build Status](https://travis-ci.com/Netflix-Skunkworks/spectatord.svg?branch=master)](https://travis-ci.com/Netflix-Skunkworks/spectatord)
 
 > :warning: Experimental
 

--- a/dependencies.bzl
+++ b/dependencies.bzl
@@ -2,16 +2,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def nflx_spectatord_deps():
   http_archive(
-          name = "spectator_cfg",
-          build_file = "@nflx_spectatord//third_party:spectator_cfg.BUILD",
-          urls = ["https://stash.corp.netflix.com/rest/api/latest/projects/CLDMTA/repos/netflix-spectator-cppconf/archive?at=e2fa37ea6fed338a3fe7b12c7701ec086d4c5713&format=zip"],
-          sha256 = "08be5c03f7f90c7c8727a2ca395048b9651ca48620bd978db530414ff7b7d666",
-          type = "zip",
-      )
-
-    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
-  http_archive(
-          # Needs build file updates to build with reverse fqdn.
           name = "curl",
           build_file = "@nflx_spectatord//third_party:curl.BUILD",
           strip_prefix = "curl-7.72.0",
@@ -19,7 +9,6 @@ def nflx_spectatord_deps():
           urls = [ "https://curl.haxx.se/download/curl-7.72.0.tar.gz", ],
           )
 
-  # https://github.com/grpc/grpc/blob/master/bazel/grpc_deps.bzl.
   http_archive(
           name = "com_github_c_ares_c_ares",
           build_file = "@nflx_spectatord//third_party/cares:cares.BUILD",
@@ -28,7 +17,6 @@ def nflx_spectatord_deps():
           url = "https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz",
           )
 
-  # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
   http_archive(
           name = "boringssl",
           sha256 = "1188e29000013ed6517168600fc35a010d58c5d321846d6a6dfee74e4c788b45",
@@ -36,7 +24,6 @@ def nflx_spectatord_deps():
           urls = ["https://github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz"],
           )
 
-  # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
   http_archive(
           name = "net_zlib",
           build_file = "@nflx_spectatord//third_party:zlib.BUILD",
@@ -145,6 +132,15 @@ def nflx_spectatord_deps():
           build_file = "@nflx_spectatord//third_party:backward.BUILD",
           sha256 = "97ddc265cc42afadf870ccfa9b079382766eb9e46e8fc1994a61a92ff547c851",
           )
+
+  # netflix internal config
+  http_archive(
+          name = "nflx_spectator_cfg",
+          build_file = "@nflx_spectatord//third_party:spectator_cfg.BUILD",
+          urls = ["https://stash.corp.netflix.com/rest/api/latest/projects/CLDMTA/repos/netflix-spectator-cppconf/archive?at=e2fa37ea6fed338a3fe7b12c7701ec086d4c5713&format=zip"],
+          sha256 = "08be5c03f7f90c7c8727a2ca395048b9651ca48620bd978db530414ff7b7d666",
+          type = "zip",
+      )
 
   # C++ rules for Bazel.
   http_archive(

--- a/spectator/sample_config.cc
+++ b/spectator/sample_config.cc
@@ -1,9 +1,16 @@
 #include "config.h"
 
+
 namespace spectator {
 
+// used in tests
 std::unique_ptr<Config> GetConfiguration() {
   return std::make_unique<Config>();
 }
 
 }  // namespace spectator
+
+std::unique_ptr<spectator::Config> GetSpectatorConfig() {
+  return spectator::GetConfiguration(); 
+}
+


### PR DESCRIPTION
`spectatord_main` had a direct dependency on an internal config package
used at Netflix. This is not accessible from outside the internal
network and therefore travis cannot successfully complete the build.