### PR TITLE
Tweak travis build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,4 +37,3 @@ build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
 build:ubsan --linkopt -lubsan
 
-test --test_output=streamed

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,7 @@ env:
     - LANG="en_US.UTF-8"
 
 script:
-  - bazel-3.5.0 \
-      --output_user_root=$HOME/.cache/bazel/$TRAVIS_COMPILER \
-      --batch \
-      build --config asan spectatord_test spectator_test spectatord_main \
-      --verbose_failures
+  - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel/$TRAVIS_COMPILER --batch build --config asan spectatord_test spectator_test spectatord_main --verbose_failures
   - bazel-bin/spectator_test && bazel-bin/spectatord_test
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ env:
     - LANG="en_US.UTF-8"
 
 script:
-  - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel build --config asan spectator_test spectatord_test spectatord_main
-  -  bazel-3.5.0 \
+  - bazel-3.5.0 \
       --output_user_root=$HOME/.cache/bazel/$TRAVIS_COMPILER \
       --batch \
       build --config asan spectatord_test spectator_test spectatord_main \

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,15 @@ env:
     - LANG="en_US.UTF-8"
 
 script:
-  - bazel-3.5.0 build --config asan spectator_test spectatord_test spectatord_main
+  - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel build --config asan spectator_test spectatord_test spectatord_main
+  -  bazel-3.5.0 \
+      --output_user_root=$HOME/.cache/bazel/$TRAVIS_COMPILER \
+      --batch \
+      build --config asan spectatord_test spectator_test spectatord_main \
+      --verbose_failures
   - bazel-bin/spectator_test && bazel-bin/spectatord_test
 
 cache:
   directories:
-  - $HOME/.cache/bazel
+  - $HOME/.cache/bazel/clang
+  - $HOME/.cache/bazel/gcc


### PR DESCRIPTION
Trying to improve the performance of the travis builds. It's currently
taking around 9 and 11 minutes for clang and gcc respectively.