### PR TITLE
Only compile using clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,11 @@ addons:
       - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
       - bazel-3.5.0
-      - g++-10 
       - clang-11
       - binutils-dev
 
 matrix:
   include:
-    - os: linux
-      compiler: gcc
-      env: CC='gcc-10' CXX='g++-10'
     - os: linux
       compiler: clang
       env: CC='clang-11' CXX='clang++-11'
@@ -29,10 +25,9 @@ env:
     - LANG="en_US.UTF-8"
 
 script:
-  - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel/$TRAVIS_COMPILER --batch build --config asan spectatord_test spectator_test spectatord_main --verbose_failures
+  - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel --batch build --config asan spectatord_test spectator_test spectatord_main --verbose_failures
   - bazel-bin/spectator_test && bazel-bin/spectatord_test
 
 cache:
   directories:
-  - $HOME/.cache/bazel/clang
-  - $HOME/.cache/bazel/gcc
+  - $HOME/.cache/bazel


### PR DESCRIPTION
For travis just focus on the clang build for now since the gcc is taking
a long time. We might re-enable it in the future if we find a more
performant way of executing multiple builds while caching the
dependencies