### PR TITLE
Statically link against libbfd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - bazel-3.5.0
       - clang-11
       - binutils-dev
+      - libiberty-dev
 
 matrix:
   include:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -209,7 +209,8 @@ cc_binary(
         }),
     malloc = memory_allocator,
     linkopts = select({
-        "@bazel_tools//src/conditions:linux_x86_64": ["-lbfd", "-ldl"],
+        "@bazel_tools//src/conditions:linux_x86_64": [
+            "/usr/lib/x86_64-linux-gnu/libbfd.a", "/usr/lib/x86_64-linux-gnu/libiberty.a", "-ldl"],
         "//conditions:default": [],
         }),
     includes = ["server"],


### PR DESCRIPTION
In order to reduce dependencies on system libraries. This makes it
possible to compile on bionic and run on xenial.