### PR TITLE
Remove registry specific Id creation

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,5 +1,4 @@
-# Benchmarks
-
+#Benchmarks
 
 ## Benchmarking different table implementations to keep meters in the registry
 

--- a/bench/get_measurement_bench.cc
+++ b/bench/get_measurement_bench.cc
@@ -23,11 +23,11 @@ bench_get_measurement_strview       2488 ns         2488 ns       284401
 */
 
 #include <benchmark/benchmark.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <iostream>
 #include "spectatord.h"
 
+using spectator::Id;
 using spectatord::measurement;
+
 std::optional<measurement> get_measurement_ptr(
     const spectator::Registry* registry, const char* measurement_str,
     std::string* err_msg) {
@@ -81,7 +81,7 @@ std::optional<measurement> get_measurement_ptr(
     }
   }
 
-  auto id = registry->CreateId(std::move(name), std::move(tags));
+  auto id = Id::Of(name, std::move(tags));
   return measurement{std::move(id), value};
 }
 
@@ -129,7 +129,7 @@ std::optional<measurement> get_measurement_strchr(
     }
   }
 
-  auto id = registry->CreateId(std::move(name), std::move(tags));
+  auto id = Id::Of(std::move(name), std::move(tags));
   return measurement{std::move(id), value};
 }
 
@@ -179,7 +179,7 @@ std::optional<measurement> get_measurement_strview(
     }
   }
 
-  auto id = registry->CreateId(name, std::move(tags));
+  auto id = Id::Of(name, std::move(tags));
   return measurement{std::move(id), value};
 }
 
@@ -226,7 +226,6 @@ static void bench_get_measurement_strview(benchmark::State& state) {
   bench_get_measurement_fun(state, get_measurement_strview);
 }
 
-auto logger = spdlog::stdout_color_mt("bench");
 BENCHMARK(bench_get_measurement_ptr);
 BENCHMARK(bench_get_measurement_strchr);
 BENCHMARK(bench_get_measurement_strview);

--- a/spectator/http_client_test.cc
+++ b/spectator/http_client_test.cc
@@ -20,6 +20,7 @@ using spectator::gzip_uncompress;
 using spectator::HttpClient;
 using spectator::HttpClientConfig;
 using spectator::HttpResponse;
+using spectator::Id;
 using spectator::intern_str;
 using spectator::Registry;
 using spectator::Tags;
@@ -264,7 +265,7 @@ TEST(HttpTest, Get) {
       {"ipc.result", "success"}, {"owner", "spectator-cpp"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", "GET"},    {"ipc.endpoint", "/get"}};
-  auto timer_id = registry.CreateId("ipc.client.call", timer_tags);
+  auto timer_id = Id::Of("ipc.client.call", std::move(timer_tags));
   auto timer = registry.GetTimer(timer_id);
   EXPECT_EQ(timer->Count(), 1);
 }
@@ -301,12 +302,12 @@ TEST(HttpTest, Get503) {
       {"ipc.result", "success"}, {"owner", "spectator-cpp"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", "GET"},    {"ipc.endpoint", "/get503"}};
-  auto err_id = registry.CreateId("ipc.client.call", err_timer_tags);
+  auto err_id = Id::Of("ipc.client.call", std::move(err_timer_tags));
   auto err_timer = registry.GetTimer(err_id);
   EXPECT_EQ(err_timer->Count(), 1);
 
-  auto success_id = registry.CreateId("ipc.client.call", success_timer_tags);
-  auto success_timer = registry.GetTimer(success_id);
+  auto success_timer =
+      registry.GetTimer("ipc.client.call", std::move(success_timer_tags));
   EXPECT_EQ(success_timer->Count(), 1);
 }
 
@@ -338,7 +339,7 @@ void test_method_header(const std::string& method) {
       {"ipc.result", "success"}, {"owner", "spectator-cpp"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", method},   {"ipc.endpoint", "/getheader"}};
-  auto timer_id = registry.CreateId("ipc.client.call", timer_tags);
+  auto timer_id = Id::Of("ipc.client.call", std::move(timer_tags));
   auto timer = registry.GetTimer(timer_id);
   EXPECT_EQ(timer->Count(), 1);
 }

--- a/spectator/log_entry.h
+++ b/spectator/log_entry.h
@@ -12,11 +12,10 @@ class LogEntry {
            const std::string& url)
       : registry_{registry},
         start_{absl::Now()},
-        id_{registry_->CreateId("ipc.client.call",
-                                Tags{{"owner", "spectator-cpp"},
-                                     {"ipc.endpoint", PathFromUrl(url)},
-                                     {"http.method", method},
-                                     {"http.status", "-1"}})} {}
+        id_{Id::Of("ipc.client.call", {{"owner", "spectator-cpp"},
+                                       {"ipc.endpoint", PathFromUrl(url)},
+                                       {"http.method", method},
+                                       {"http.status", "-1"}})} {}
 
   [[nodiscard]] absl::Time start() const { return start_; }
 

--- a/spectator/perc_dist_summary_test.cc
+++ b/spectator/perc_dist_summary_test.cc
@@ -9,8 +9,7 @@ using namespace spectator;
 
 template <class T>
 std::unique_ptr<T> getDS(Registry* r) {
-  auto id = r->CreateId("ds", Tags{});
-  return std::make_unique<T>(r, id, 0, 1000 * 1000);
+  return std::make_unique<T>(r, Id::Of("ds"), 0, 1000 * 1000);
 }
 
 using Implementations = testing::Types<PercentileDistributionSummary>;
@@ -21,7 +20,7 @@ class PercentileDistributionSummaryTest : public ::testing::Test {
   PercentileDistributionSummaryTest()
       : r{GetConfiguration(), DefaultLogger()},
         ds{getDS<T>(&r)},
-        restricted_ds{&r, r.CreateId("ds2", Tags{}), 5, 2000} {}
+        restricted_ds{&r, Id::Of("ds2"), 5, 2000} {}
 
   Registry r;
   std::unique_ptr<T> ds;

--- a/spectator/perc_timer_test.cc
+++ b/spectator/perc_timer_test.cc
@@ -9,7 +9,7 @@ using namespace spectator;
 
 template <class T>
 std::unique_ptr<T> getTimer(Registry* r) {
-  auto id = r->CreateId("t", Tags{});
+  auto id = Id::Of("t");
   return std::make_unique<T>(r, id, absl::ZeroDuration(), absl::Seconds(100));
 }
 
@@ -21,7 +21,7 @@ class PercentileTimerTest : public ::testing::Test {
   PercentileTimerTest()
       : r{GetConfiguration(), DefaultLogger()},
         timer{getTimer<T>(&r)},
-        restricted_timer{&r, r.CreateId("t2", Tags{}), absl::Milliseconds(5),
+        restricted_timer{&r, Id::Of("t2"), absl::Milliseconds(5),
                          absl::Seconds(2)} {}
   Registry r;
   std::unique_ptr<T> timer;

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -25,8 +25,7 @@ namespace detail {
 template <typename R>
 std::shared_ptr<Counter> get_counter(R* registry, Tags tags) {
   static constexpr auto kSpectatorMeasurements = "spectator.measurements";
-  return registry->GetCounter(
-      registry->CreateId(kSpectatorMeasurements, std::move(tags)));
+  return registry->GetCounter(kSpectatorMeasurements, std::move(tags));
 }
 }  // namespace detail
 

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -23,17 +23,13 @@ const Config& Registry::GetConfig() const noexcept { return *config_; }
 
 Registry::logger_ptr Registry::GetLogger() const noexcept { return logger_; }
 
-Id Registry::CreateId(std::string_view name, Tags tags) const noexcept {
-  return Id(intern_str(name), std::move(tags));
-}
-
 std::shared_ptr<Counter> Registry::GetCounter(Id id) noexcept {
   return all_meters_.insert_counter(std::move(id));
 }
 
 std::shared_ptr<Counter> Registry::GetCounter(std::string_view name,
                                               Tags tags) noexcept {
-  return GetCounter(CreateId(name, std::move(tags)));
+  return GetCounter(Id::Of(name, std::move(tags)));
 }
 
 std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
@@ -43,7 +39,7 @@ std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
 
 std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
     std::string_view name, Tags tags) noexcept {
-  return GetDistributionSummary(CreateId(name, std::move(tags)));
+  return GetDistributionSummary(Id::Of(name, std::move(tags)));
 }
 
 std::shared_ptr<Gauge> Registry::GetGauge(Id id) noexcept {
@@ -58,7 +54,7 @@ std::shared_ptr<Gauge> Registry::GetGauge(Id id, absl::Duration ttl) noexcept {
 
 std::shared_ptr<Gauge> Registry::GetGauge(std::string_view name,
                                           Tags tags) noexcept {
-  return GetGauge(CreateId(name, std::move(tags)));
+  return GetGauge(Id::Of(name, std::move(tags)));
 }
 
 std::shared_ptr<MaxGauge> Registry::GetMaxGauge(Id id) noexcept {
@@ -67,7 +63,7 @@ std::shared_ptr<MaxGauge> Registry::GetMaxGauge(Id id) noexcept {
 
 std::shared_ptr<MaxGauge> Registry::GetMaxGauge(std::string_view name,
                                                 Tags tags) noexcept {
-  return GetMaxGauge(CreateId(name, std::move(tags)));
+  return GetMaxGauge(Id::Of(name, std::move(tags)));
 }
 
 std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
@@ -77,7 +73,7 @@ std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
 
 std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
     std::string_view name, Tags tags) noexcept {
-  return GetMonotonicCounter(CreateId(name, std::move(tags)));
+  return GetMonotonicCounter(Id::Of(name, std::move(tags)));
 }
 
 std::shared_ptr<MonotonicSampled> Registry::GetMonotonicSampled(
@@ -96,7 +92,7 @@ std::shared_ptr<Timer> Registry::GetTimer(Id id) noexcept {
 
 std::shared_ptr<Timer> Registry::GetTimer(std::string_view name,
                                           Tags tags) noexcept {
-  return GetTimer(CreateId(name, std::move(tags)));
+  return GetTimer(Id::Of(name, std::move(tags)));
 }
 
 void Registry::Start() noexcept {

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -201,8 +201,6 @@ class Registry {
 
   void OnMeasurements(measurements_callback fn) noexcept;
 
-  Id CreateId(std::string_view name, Tags tags) const noexcept;
-
   std::shared_ptr<Counter> GetCounter(Id id) noexcept;
   std::shared_ptr<Counter> GetCounter(std::string_view name,
                                       Tags tags = {}) noexcept;

--- a/spectator/registry_test.cc
+++ b/spectator/registry_test.cc
@@ -6,6 +6,7 @@
 namespace {
 using spectator::DefaultLogger;
 using spectator::GetConfiguration;
+using spectator::Id;
 using spectator::Registry;
 using spectator::Tags;
 
@@ -156,8 +157,7 @@ TEST(Registry, OnMeasurements) {
   auto found = false;
   auto cb = [&](const std::vector<spectator::Measurement>& ms) {
     called = true;
-    auto id =
-        r.CreateId("some.counter", spectator::Tags{{"statistic", "count"}});
+    auto id = Id::Of("some.counter", {{"statistic", "count"}});
     auto expected = spectator::Measurement{id, 1.0};
     auto it = std::find(ms.begin(), ms.end(), expected);
     found = it != ms.end();

--- a/spectator/sample_config.cc
+++ b/spectator/sample_config.cc
@@ -1,6 +1,5 @@
 #include "config.h"
 
-
 namespace spectator {
 
 // used in tests
@@ -11,6 +10,5 @@ std::unique_ptr<Config> GetConfiguration() {
 }  // namespace spectator
 
 std::unique_ptr<spectator::Config> GetSpectatorConfig() {
-  return spectator::GetConfiguration(); 
+  return spectator::GetConfiguration();
 }
-


### PR DESCRIPTION
Previously the way we were creating `Id`s was to use
`registry->CreateId(...)` with the idea of being able to have `Id`s that
were customized to a particular registry. This hasn't been needed at all
and it just makes things too verbose. Switch the creation to
`Id::Of(name, [tags])` instead.