### PR TITLE
New payload fmt and add monotonically sampled ctrs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,7 +17,7 @@ cc_library(
     srcs = ["spectator/common_refs.cc", "spectator/compressed_buffer.cc",
             "spectator/counter.cc", "spectator/dist_summary.cc", "spectator/gauge.cc", "spectator/gzip.cc",
             "spectator/http_client.cc", "spectator/id.cc", "spectator/logger.cc", "spectator/max_gauge.cc",
-            "spectator/monotonic_counter.cc",
+            "spectator/monotonic_counter.cc", "spectator/monotonic_sampled.cc",
             "spectator/percentile_buckets.cc", "spectator/registry.cc",
             "spectator/smile.cc", "spectator/strings.cc", "spectator/string_pool.cc",
             "spectator/timer.cc"],
@@ -28,7 +28,7 @@ cc_library(
             "spectator/gzip.h", "spectator/http_client.h", "spectator/id.h",
             "spectator/log_entry.h", "spectator/logger.h",
             "spectator/max_gauge.h", "spectator/measurement.h",
-            "spectator/meter.h", "spectator/monotonic_counter.h",
+            "spectator/meter.h", "spectator/monotonic_counter.h", "spectator/monotonic_sampled.h",
             "spectator/percentile_buckets.h",
             "spectator/percentile_distribution_summary.h", "spectator/percentile_timer.h",
             "spectator/publisher.h", "spectator/registry.h",
@@ -106,11 +106,12 @@ genrule(
 cc_test(
     name = "spectator_test",
     srcs = glob(["spectator/*test.cc", 
-                 "spectator/http_server.*", "spectator/test_utils.*"]),
+                 "spectator/http_server.*", "spectator/test_utils.*", "bin/test_main.cc"]),
     deps = [
         ":spectator",
         ":dummy_cfg",
-        "@com_google_googletest//:gtest_main",
+        "@com_github_bombela_backward//:backward",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -148,11 +149,12 @@ cc_library(
 
 cc_test(
     name = "spectatord_test",
-    srcs = ["server/spectatord_test.cc", "server/proc_utils_test.cc"],
+    srcs = ["bin/test_main.cc", "server/spectatord_test.cc", "server/proc_utils_test.cc"],
     data = glob(["test-resources/*"]),
     deps = [
         ":spectatord",
-        "@com_google_googletest//:gtest_main",
+        "@com_github_bombela_backward//:backward",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ and on the Unix domain socket `/run/spectatord/spectatord.unix`
 ## Examples
 
 ```
-$ echo "1:c:server.numRequests:#id=failed:1" | nc -u -w0 localhost 1234
-$ echo "1:t:server.requestLatency:0.042" | nc -u -w0 localhost 1234
-$ echo "1:d:server.responseSizes:1024" | nc -w0 -uU /run/spectatord/spectatord.unix
+$ echo "c:server.numRequests,id=failed:1" | nc -u -w0 localhost 1234
+$ echo "t:server.requestLatency:0.042" | nc -u -w0 localhost 1234
+$ echo "d:server.responseSizes:1024" | nc -w0 -uU /run/spectatord/spectatord.unix
+$ echo "g:someGauge:60" | nc -w0 -uU /run/spectatord/spectatord.unix
+$ echo "X,1543160297100:monotonic.Source:42" | nc -w0 -uU /run/spectatord/spectatord.unix
+$ echo "X,1543160298100:monotonic.Source:43" | nc -w0 -uU /run/spectatord/spectatord.unix
 ```
 
 ## Format
@@ -28,14 +31,12 @@ $ echo "1:d:server.responseSizes:1024" | nc -w0 -uU /run/spectatord/spectatord.u
 The message sent to the server has the following format:
 
 ```
-protocol:metric-type:name:#tags:value
+metric-type:name,tags:value@timestamp
 ```
 
+where `tags` and `@timestamp` are optional.
+
 Multiple lines might be send in the same packet separated by newlines (`\n`).
-
-### Protocol
-
-Currently the only supported protocol is 1.
 
 ### Metric Types
 
@@ -46,19 +47,27 @@ Currently the only supported protocol is 1.
              can follow the `g` preceded by a comma. Otherwise the value will have
              a TTL of 15 minutes. For example:
              ```
-             1:g,5:gauge:42.0
+             g,5:gauge:42.0
              ```
              This will use a 5s TTL.
 * `m` Max Gauge. This will report the maximum value to the aggregator
 * `C` Monotonic Counters. To track monotonic sources. `spectatord`
-will convert it to a rate once it receives a second sample.
+will convert it to a delta once it receives a second sample.
 * `D` Percentile Distribution Summary
 * `T` Percentile Timer. The value is expressed in seconds
+* `X` Monotonic Counters sampled at a given time. This is an experimental type
+that can be used to track monotonic sources that were sampled in the recent 
+past. The timestamp in milliseconds of when the reported value was sampled must 
+be included after the `X` preceded by a comma.
 
 ### Name and Tags
 
 The name must follow the atlas restrictions. For naming conventions see
 [Spectator Naming Conventions](https://netflix.github.io/spectator/en/latest/intro/conventions/)
+
+Tags are optional. They can be specified as comma separated key=value pairs. For example:
+
+`fooIsTheName,some.tag=val1,some.otherTag=val2`
 
 The restrictions on valid names and tag keys and values are:
 
@@ -75,19 +84,22 @@ The restrictions on valid names and tag keys and values are:
 Tag keys and values are only allowed to use characters in the set `-._A-Za-z0-9`. Others will
 be converted to an `_` by the client.
 
-Tags are optional, and can be set by adding a `#` after the name followed by:
-`key=value` pairs separated by commas.
-
 ### Value
 
 A double value. The meaning of the value depends on the metric type.
 
 ## Some performance numbers
 
+A key goal of this project is to have some good performance. This means we need to be able to 
+use few resources for the common use cases where the number of metric updates is relatively small 
+(fewer than 10k requests per second), and being able to scale to handle hundreds of thousands
+of updates per second when that is required.
+
 Using Unix domain sockets we can handle close to 1M metric updates per second,
 assuming the client batches the updates and sends a few at a time. Sending
-every single update is simplest and should work for the vast majority of our
-users. 
+every single metric update requires a lot of context switching but is something that
+works well for the majority of our use cases. This simplicity means the user does not have
+to maintain any local state.
 
 ```
 Transport          Batch Size    First 10M          Second 10M

--- a/bin/test_main.cc
+++ b/bin/test_main.cc
@@ -1,0 +1,8 @@
+#include "backward.hpp"
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  backward::SignalHandling sh;
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/server/spectatord.h
+++ b/server/spectatord.h
@@ -55,7 +55,7 @@ struct measurement {
   double value;
 };
 
-std::optional<measurement> get_measurement(const char* measurement_str,
+std::optional<measurement> get_measurement(std::string_view measurement_str,
                                            std::string* err_msg);
 
 }  // namespace spectatord

--- a/server/spectatord_test.cc
+++ b/server/spectatord_test.cc
@@ -189,7 +189,7 @@ TEST(Spectatord, Statsd_SampledTimer) {
 
 TEST(Spectatord, ParseOneTag) {
   auto logger = Logger();
-  char_ptr line{strdup("my.name:#foo=bar:42.0")};
+  char_ptr line{strdup("my.name,foo=bar:42.0")};
   std::string err_msg;
   auto measurement = *(get_measurement(line.get(), &err_msg));
   logger->info("Got {} = {}", measurement.id, measurement.value);
@@ -201,7 +201,7 @@ TEST(Spectatord, ParseOneTag) {
 
 TEST(Spectatord, ParseMultipleTags) {
   auto logger = Logger();
-  char_ptr line{strdup("n:#foo=bar,k=v1,k2=v2:2")};
+  char_ptr line{strdup("n,foo=bar,k=v1,k2=v2:2")};
   std::string err_msg;
   auto measurement = *get_measurement(line.get(), &err_msg);
   logger->info("Got {} = {}", measurement.id, measurement.value);

--- a/spectator/id.cc
+++ b/spectator/id.cc
@@ -32,9 +32,4 @@ Id Id::WithTags(Tags&& extra_tags) const {
   return Id(Name(), std::move(tags));
 }
 
-std::ostream& operator<<(std::ostream& os, const Id& id) {
-  os << "Id(" << id.Name().Get() << ", " << id.GetTags() << ")";
-  return os;
-}
-
 }  // namespace spectator

--- a/spectator/id.h
+++ b/spectator/id.h
@@ -17,6 +17,10 @@ class Id {
   Id(std::string_view name, Tags tags) noexcept
       : name_(intern_str(name)), tags_(std::move(tags)), hash_(0U) {}
 
+  static Id Of(std::string_view name, Tags tags = {}) {
+    return Id(name, std::move(tags));
+  }
+
   bool operator==(const Id& rhs) const noexcept;
 
   StrRef Name() const noexcept;
@@ -38,7 +42,9 @@ class Id {
     return baseId.WithStat(stat);
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const Id& id);
+  friend std::ostream& operator<<(std::ostream& os, const Id& id) {
+    return os << fmt::format("{}", id);
+  }
 
   friend struct std::hash<Id>;
 
@@ -85,4 +91,18 @@ struct equal_to<shared_ptr<spectator::Id>> {
     return *lhs == *rhs;
   }
 };
+
 }  // namespace std
+
+template <>
+struct fmt::formatter<spectator::Id> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
+  // formatter for Ids
+  template <typename FormatContext>
+  auto format(const spectator::Id& id, FormatContext& context) {
+    return fmt::format_to(context.out(), "Id({}, {})", id.Name(), id.GetTags());
+  }
+};

--- a/spectator/monotonic_counter_test.cc
+++ b/spectator/monotonic_counter_test.cc
@@ -7,7 +7,7 @@ namespace {
 using spectator::refs;
 
 spectator::MonotonicCounter getMonotonicCounter(std::string_view name) {
-  return spectator::MonotonicCounter(spectator::Id(name, spectator::Tags{}));
+  return spectator::MonotonicCounter(spectator::Id::Of(name));
 }
 
 TEST(MonotonicCounter, Init) {

--- a/spectator/monotonic_sampled.cc
+++ b/spectator/monotonic_sampled.cc
@@ -1,0 +1,57 @@
+#include "monotonic_sampled.h"
+
+namespace spectator {
+
+static constexpr auto kNaN = std::numeric_limits<double>::quiet_NaN();
+
+MonotonicSampled::MonotonicSampled(Id id) noexcept
+    : Meter{std::move(id)},
+      value_{kNaN},
+      prev_value_{kNaN},
+      ts_{0},
+      prev_ts_{0} {}
+
+void MonotonicSampled::Set(double amount, int64_t ts_nanos) noexcept {
+  Update();
+
+  absl::MutexLock lock(&mutex_);
+  // ignore out of order points, or wrap arounds
+  if (ts_nanos < ts_) {
+    return;
+  }
+  // only update prev values at most once per reporting interval
+  if (std::isnan(prev_value_)) {
+    prev_value_ = value_;
+    prev_ts_ = ts_;
+  }
+  value_ = amount;
+  ts_ = ts_nanos;
+}
+
+void MonotonicSampled::Measure(Measurements* results) const noexcept {
+  auto sampled_delta = SampledRate();
+  if (std::isnan(sampled_delta)) {
+    return;
+  }
+
+  {
+    absl::MutexLock lock(&mutex_);
+    prev_value_ = value_;
+    prev_ts_ = ts_;
+  }
+
+  if (sampled_delta > 0) {
+    if (!count_id_) {
+      count_id_ = std::make_unique<Id>(MeterId().WithStat(refs().count()));
+    }
+    results->emplace_back(*count_id_, sampled_delta);
+  }
+}
+
+double MonotonicSampled::SampledRate() const noexcept {
+  absl::MutexLock lock(&mutex_);
+  auto delta_t = (ts_ - prev_ts_) / 1e9;
+  return (value_ - prev_value_) / delta_t;
+}
+
+}  // namespace spectator

--- a/spectator/monotonic_sampled.h
+++ b/spectator/monotonic_sampled.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "meter.h"
+#include "absl/synchronization/mutex.h"
+
+namespace spectator {
+class MonotonicSampled : public Meter {
+ public:
+  explicit MonotonicSampled(Id id) noexcept;
+  void Measure(Measurements* results) const noexcept;
+
+  void Set(double amount, int64_t ts_nanos) noexcept;
+  double SampledRate() const noexcept;
+
+ private:
+  mutable std::unique_ptr<Id> count_id_;
+  mutable absl::Mutex mutex_;
+  double value_ GUARDED_BY(mutex_);
+  mutable double prev_value_ GUARDED_BY(mutex_);
+  int64_t ts_ GUARDED_BY(mutex_);
+  mutable int64_t prev_ts_ GUARDED_BY(mutex_);
+};
+}  // namespace spectator

--- a/spectator/monotonic_sampled_test.cc
+++ b/spectator/monotonic_sampled_test.cc
@@ -1,0 +1,94 @@
+#include "../spectator/monotonic_sampled.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+using spectator::refs;
+
+auto getMonotonicSampled(std::string_view name) {
+  return spectator::MonotonicSampled(spectator::Id::Of(name));
+}
+
+auto s_to_ns(int seconds) { return int64_t(1000) * 1000 * 1000 * seconds; }
+
+TEST(MonotonicSampled, Init) {
+  auto c = getMonotonicSampled("foo");
+  EXPECT_TRUE(std::isnan(c.SampledRate()));
+
+  c.Set(42, s_to_ns(1));
+  EXPECT_TRUE(std::isnan(c.SampledRate()));
+
+  spectator::Measurements ms;
+  c.Measure(&ms);
+  ASSERT_TRUE(ms.empty());
+
+  c.Set(84, s_to_ns(2));
+  EXPECT_DOUBLE_EQ(c.SampledRate(), 42.0);
+}
+
+TEST(MonotonicSampled, NegativeDelta) {
+  auto c = getMonotonicSampled("neg");
+  EXPECT_TRUE(std::isnan(c.SampledRate()));
+
+  spectator::Measurements ms;
+  c.Set(100.0, s_to_ns(1));
+  c.Measure(&ms);
+  EXPECT_TRUE(ms.empty());
+
+  c.Set(99.0, s_to_ns(2));
+  c.Measure(&ms);
+  EXPECT_TRUE(ms.empty());
+
+  c.Set(98.0, s_to_ns(3));
+  c.Measure(&ms);
+  EXPECT_TRUE(ms.empty());
+
+  c.Set(100.0, s_to_ns(4));
+  c.Measure(&ms);
+  ASSERT_EQ(ms.size(), 1);
+  auto id = c.MeterId().WithStat(refs().count());
+  auto expected = spectator::Measurement{id, 2.0};
+  EXPECT_EQ(expected, ms.front());
+}
+
+TEST(MonotonicSampled, Id) {
+  auto c = getMonotonicSampled("id");
+  auto id = spectator::Id::Of("id");
+  EXPECT_EQ(c.MeterId(), id);
+}
+
+TEST(MonotonicSampled, Measure) {
+  auto c = getMonotonicSampled("measure");
+  c.Set(42, s_to_ns(4));
+  spectator::Measurements measures;
+  c.Measure(&measures);
+  ASSERT_TRUE(measures.empty());  // initialize
+
+  EXPECT_TRUE(std::isnan(c.SampledRate()))
+      << "MonotonicSamples should reset their value after being measured";
+
+  c.Set(84.0, s_to_ns(5));
+  c.Measure(&measures);
+  using spectator::Measurement;
+  auto id = c.MeterId().WithStat(refs().count());
+  std::vector<Measurement> expected({{id, 42.0}});
+  EXPECT_EQ(expected, measures);
+
+  measures.clear();
+  c.Measure(&measures);
+  EXPECT_TRUE(measures.empty())
+      << "MonotonicSampleds should not report delta=0";
+}
+
+TEST(MonotonicSampled, Update) {
+  auto counter = getMonotonicSampled("m");
+  counter.Set(1, s_to_ns(1));
+
+  auto t1 = counter.Updated();
+  auto t2 = counter.Updated();
+  EXPECT_EQ(t1, t2);
+  usleep(1);
+  counter.Set(2, s_to_ns(2));
+  EXPECT_TRUE(counter.Updated() > t1);
+}
+}  // namespace

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -80,6 +80,16 @@ std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
   return GetMonotonicCounter(CreateId(name, std::move(tags)));
 }
 
+std::shared_ptr<MonotonicSampled> Registry::GetMonotonicSampled(
+    Id id) noexcept {
+  return all_meters_.insert_mono_sampled(std::move(id));
+}
+
+std::shared_ptr<MonotonicSampled> Registry::GetMonotonicSampled(
+    std::string_view name, Tags tags) noexcept {
+  return GetMonotonicSampled(Id::Of(name, std::move(tags)));
+}
+
 std::shared_ptr<Timer> Registry::GetTimer(Id id) noexcept {
   return all_meters_.insert_timer(std::move(id));
 }

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -10,6 +10,7 @@
 #include "monotonic_counter.h"
 #include "publisher.h"
 #include "timer.h"
+#include "spectator/monotonic_sampled.h"
 #include <condition_variable>
 #include <mutex>
 #include <spdlog/spdlog.h>
@@ -103,6 +104,7 @@ struct all_meters {
   meter_map<Gauge> gauges_;
   meter_map<MaxGauge> max_gauges_;
   meter_map<MonotonicCounter> mono_counters_;
+  meter_map<MonotonicSampled> mono_sampled_;
   meter_map<Timer> timers_;
 
   size_t size() const {
@@ -165,6 +167,11 @@ struct all_meters {
         std::make_shared<MonotonicCounter>(std::move(id)));
   }
 
+  auto insert_mono_sampled(Id id) {
+    return mono_sampled_.insert(
+        std::make_shared<MonotonicSampled>(std::move(id)));
+  }
+
   auto insert_dist_sum(Id id) {
     return dist_sums_.insert(
         std::make_shared<DistributionSummary>(std::move(id)));
@@ -202,6 +209,10 @@ class Registry {
 
   std::shared_ptr<MonotonicCounter> GetMonotonicCounter(Id id) noexcept;
   std::shared_ptr<MonotonicCounter> GetMonotonicCounter(
+      std::string_view name, Tags tags = {}) noexcept;
+
+  std::shared_ptr<MonotonicSampled> GetMonotonicSampled(Id id) noexcept;
+  std::shared_ptr<MonotonicSampled> GetMonotonicSampled(
       std::string_view name, Tags tags = {}) noexcept;
 
   std::shared_ptr<DistributionSummary> GetDistributionSummary(Id id) noexcept;

--- a/spectator/registry_test.cc
+++ b/spectator/registry_test.cc
@@ -96,7 +96,7 @@ TEST(Registry, MeasurementTest) {
   auto m = ms.front();
   // test to string
   auto str = fmt::format("{}", m);
-  EXPECT_EQ(str, "Measurement{Id(c, [statistic->count]),1}");
+  EXPECT_EQ(str, "Measurement{Id(c, {statistic->count}),1}");
 
   // test equals
   c->Increment();

--- a/spectator/string_intern.h
+++ b/spectator/string_intern.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <string>
+#include <fmt/format.h>
 
 namespace spectator {
 
@@ -46,3 +47,12 @@ struct hash<spectator::StrRef> {
   }
 };
 }  // namespace std
+
+template <>
+struct fmt::formatter<spectator::StrRef> : fmt::formatter<std::string_view> {
+  template <typename FormatContext>
+  auto format(const spectator::StrRef& s, FormatContext& context) {
+    std::string_view str_view{s.Get(), s.Length()};
+    return fmt::formatter<std::string_view>::format(str_view, context);
+  }
+};

--- a/spectator/tags.h
+++ b/spectator/tags.h
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <array>
 #include <memory>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <ostream>
 
 namespace spectator {
@@ -199,17 +201,19 @@ class Tags {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Tags& tags) {
-  bool key = true;
-  os << '[';
-  for (const auto& tag : tags) {
-    if (key) {
-      key = false;
-    } else {
-      os << ", ";
-    }
-    os << tag.key.Get() << "->" << tag.value.Get();
-  }
-  os << ']';
-  return os;
+  return os << fmt::format("{}", tags);
 }
 }  // namespace spectator
+
+template <>
+struct fmt::formatter<spectator::Tag> {
+  constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
+  // formatter for Ids
+  template <typename FormatContext>
+  auto format(const spectator::Tag& tag, FormatContext& context) {
+    return fmt::format_to(context.out(), "{}->{}", tag.key, tag.value);
+  }
+};


### PR DESCRIPTION
Update the payload format by removing the protocol version and
introducing tags with a comma instead of `:#`

In order to help implement some sidecars that are relaying samples from
other sources, we add a new meter type which is a monotonic source that
was sampled at a given time in the recent past using the type `X`. This
is experimental and subject to be removed based on feedback.

`X,1000:some.name:1`
`X,2000:some.name:2`