### PR TITLE
Make sure to zero terminate proc strings

### DIFF
--- a/server/proc_utils.cc
+++ b/server/proc_utils.cc
@@ -25,6 +25,7 @@ int max_buffer_size(const char* proc_file) {
     char buf[4096];
     int n = read(fd, buf, sizeof buf);
     if (n > 0) {
+      buf[n] = '\0';
       if (!absl::SimpleAtoi(buf, &result)) {
         // unable to parse
         result = kDefault;

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -300,7 +300,7 @@ static void prepare_socket_path(const std::string& socket_path) {
   if (last != std::string::npos) {
     auto dir = socket_path.substr(0, last);
     // create dir with the default umask
-    Logger()->info("Creating dir: {}", dir);
+    Logger()->debug("Creating dir: {}", dir);
     ::mkdir(dir.c_str(), 0777);
   }
 


### PR DESCRIPTION
We were not ensuring the correct termination of the string containing
a number when parsing the proc file `rmem_max`.