### PR TITLE
Add an option to trace http requests

### DIFF
--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -72,6 +72,7 @@ ABSL_FLAG(bool, debug, false,
           "Debug spectatord. All values will be sent to a dev aggregator and "
           "dropped.");
 ABSL_FLAG(bool, verbose, false, "Use verbose logging");
+ABSL_FLAG(bool, trace, false, "Trace http requests");
 ABSL_FLAG(bool, enable_statsd, false, "Enable statsd support");
 ABSL_FLAG(absl::Duration, meter_ttl, absl::Minutes(15),
           "Meter ttl: expire meters after this period of inactivity");
@@ -99,7 +100,9 @@ int main(int argc, char** argv) {
     cfg->uri =
         "http://atlas-aggr-dev.us-east-1.ieptest.netflix.net/api/v4/update";
   }
-
+  if (absl::GetFlag(FLAGS_trace)) {
+    cfg->trace_http = true;
+  }
   cfg->meter_ttl = absl::GetFlag(FLAGS_meter_ttl);
   auto spectator_logger = GetLogger("spectator");
   if (absl::GetFlag(FLAGS_verbose)) {

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -35,6 +35,7 @@ class Config {
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
   std::string uri;
+  bool trace_http = false;
 
   // sub-classes can override this method implementing custom logic
   // that can disable publishing under certain conditions

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -142,6 +142,13 @@ class CurlHandle {
     curl_easy_setopt(handle_, CURLOPT_HEADERFUNCTION, curl_capture_headers_fun);
   }
 
+  void trace_requests() {
+    // we log to stdout - might need to make it configurable
+    // in the future. For now let's keep it simple
+    curl_easy_setopt(handle_, CURLOPT_STDERR, stdout);
+    curl_easy_setopt(handle_, CURLOPT_VERBOSE, 1L);
+  }
+
  private:
   CURL* handle_;
   std::shared_ptr<CurlHeaders> headers_;
@@ -212,6 +219,9 @@ HttpResponse HttpClient::perform(const char* method, const std::string& url,
     curl.capture_headers();
   }
 
+  if (config_.trace_requests) {
+    curl.trace_requests();
+  }
   auto curl_res = curl.perform();
   auto http_code = 400;
 

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -20,6 +20,7 @@ struct HttpClientConfig {
   bool compress;
   bool read_headers;
   bool read_body;
+  bool trace_requests;
 };
 
 using HttpHeaders = std::unordered_map<std::string, std::string>;

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -250,7 +250,8 @@ class Publisher {
     if (connect_timeout == absl::ZeroDuration()) {
       connect_timeout = absl::Seconds(2);
     }
-    return HttpClientConfig{connect_timeout, read_timeout, true, false, true};
+    return HttpClientConfig{connect_timeout, read_timeout, true,
+                            false,           true,         cfg.trace_http};
   }
 
   std::pair<size_t, size_t> handle_aggr_response(

--- a/tools/metrics_gen.cc
+++ b/tools/metrics_gen.cc
@@ -149,34 +149,34 @@ metrics_t gen_metrics(const char* prefix, int num, int distinct,
   for (auto i = 0; i < num / 10; ++i) {
     auto n = i % distinct;
     raw.emplace_back(fmt::format(
-        "1:c:spectatord_test.counter:#id={}{},foo=some-foo:42.0\n", prefix, n));
+        "c:spectatord_test.counter,id={}{},foo=some-foo:42.0\n", prefix, n));
     raw.emplace_back(
-        fmt::format("1:C:spectatord_test.monocounter:#id={}{},foo=some-foo,bar="
+        fmt::format("1:C:spectatord_test.monocounter,id={}{},foo=some-foo,bar="
                     "some-bar:{}\n",
                     prefix, n, i));
     raw.emplace_back(fmt::format(
-        "1:t:spectatord_test.timer:#id={}{},foo=some-foo:0.5\n", prefix, n));
+        "t:spectatord_test.timer,id={}{},foo=some-foo:0.5\n", prefix, n));
     raw.emplace_back(fmt::format(
-        "1:d:spectatord_test.ds:#id={}{},foo=some-foo:42\n", prefix, n));
+        "d:spectatord_test.ds,id={}{},foo=some-foo:42\n", prefix, n));
     raw.emplace_back(fmt::format(
-        "1:m:spectatord_test.max:#id={}{},foo=some-foo:{}\n", prefix, n, i));
+        "m:spectatord_test.max,id={}{},foo=some-foo:{}\n", prefix, n, i));
     raw.emplace_back(
-        fmt::format("1:D:spectatord_test.percDs:#id={}{},tag1=some-tag-string,"
+        fmt::format("D:spectatord_test.percDs,id={}{},tag1=some-tag-string,"
                     "tag2=some-value:{}\n",
                     prefix, n, n % 5));
     raw.emplace_back(
-        fmt::format("1:T:spectatord_test.percTimer:#id={}{},invalid=some-"
+        fmt::format("T:spectatord_test.percTimer,id={}{},invalid=some-"
                     "invalid-string:{}\n",
                     prefix, n, n % 5));
     raw.emplace_back(fmt::format(
-        "1:c:spectatord_test.ctr:#id={}{},nf.invalid=some-invalid-string:{}\n",
+        "c:spectatord_test.ctr,id={}{},nf.invalid=some-invalid-string:{}\n",
         prefix, n, i % 5));
     raw.emplace_back(
-        fmt::format("1:c:spectatord_test.ctr2:#id={}{},foo=bar,bar=baz:{}\n",
+        fmt::format("c:spectatord_test.ctr2,id={}{},foo=bar,bar=baz:{}\n",
                     prefix, n, i % 5));
-    raw.emplace_back(fmt::format(
-        "1:g,30:spectatord_test.gauge:#id={}{},foo=bar,bar=baz:{}\n", prefix, n,
-        i % 5));
+    raw.emplace_back(
+        fmt::format("g,30:spectatord_test.gauge,id={}{},foo=bar,bar=baz:{}\n",
+                    prefix, n, i % 5));
   }
   return batch(raw, batch_size);
 }


### PR DESCRIPTION
Sometimes it can be useful when debugging certain scenarios. This
basically is just a wrapper to enable `CURLOPT_VERBOSE` sending the
output to `stdout`