### PR TITLE
Update user-agent to include the spectatord ver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - LANG="en_US.UTF-8"
 
 script:
+  - tools/generate_version.sh > spectator/version.h
   - bazel-3.5.0 --output_user_root=$HOME/.cache/bazel --batch build --config asan spectatord_test spectator_test spectatord_main --verbose_failures
   - bazel-bin/spectator_test && bazel-bin/spectatord_test
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,48 +3,79 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 config_setting(
     name = "nflx_internal",
     define_values = {
-        "nflx_internal": "1"
-        }
-    )
+        "nflx_internal": "1",
+    },
+)
 
 memory_allocator = select({
     "@bazel_tools//src/conditions:linux_x86_64": "@com_google_tcmalloc//tcmalloc",
-    "//conditions:default": "@bazel_tools//tools/cpp:malloc", 
-    })
+    "//conditions:default": "@bazel_tools//tools/cpp:malloc",
+})
 
 cc_library(
     name = "util",
     srcs = ["util/logger.cc"],
-    hdrs = ["util/files.h", "util/logger.h", ],
-    deps = ["@com_github_gabime_spdlog//:spdlog", ],
+    hdrs = ["util/files.h", "util/logger.h"],
+    deps = ["@com_github_gabime_spdlog//:spdlog"],
 )
 
 cc_library(
     name = "spectator",
-    srcs = ["spectator/common_refs.cc", "spectator/compressed_buffer.cc",
-            "spectator/counter.cc", "spectator/dist_summary.cc", "spectator/gauge.cc", "spectator/gzip.cc",
-            "spectator/http_client.cc", "spectator/id.cc", "spectator/max_gauge.cc",
-            "spectator/monotonic_counter.cc", "spectator/monotonic_sampled.cc",
-            "spectator/percentile_buckets.cc", "spectator/registry.cc",
-            "spectator/smile.cc", "spectator/strings.cc", "spectator/string_pool.cc",
-            "spectator/timer.cc"],
-    hdrs = ["spectator/atomicnumber.h", "spectator/common_refs.h", "spectator/compressed_buffer.h",
-            "spectator/config.h", "spectator/counter.h",
-            "spectator/dist_stats.h",
-            "spectator/dist_summary.h", "spectator/gauge.h",
-            "spectator/gzip.h", "spectator/http_client.h", "spectator/id.h",
-            "spectator/log_entry.h",
-            "spectator/max_gauge.h", "spectator/measurement.h",
-            "spectator/meter.h", "spectator/monotonic_counter.h", "spectator/monotonic_sampled.h",
-            "spectator/percentile_buckets.h",
-            "spectator/percentile_distribution_summary.h", "spectator/percentile_timer.h",
-            "spectator/publisher.h", "spectator/registry.h",
-            "spectator/smile.h",
-            "spectator/strings.h", "spectator/string_intern.h", "spectator/string_pool.h",
-            "spectator/tags.h",
-            "spectator/timer.h", "spectator/util.h",
-            "percentile_bucket_tags.inc", "percentile_bucket_values.inc", "valid_chars.inc",
-            "spectator/detail/perc_policy.h"],
+    srcs = [
+        "spectator/common_refs.cc",
+        "spectator/compressed_buffer.cc",
+        "spectator/counter.cc",
+        "spectator/dist_summary.cc",
+        "spectator/gauge.cc",
+        "spectator/gzip.cc",
+        "spectator/http_client.cc",
+        "spectator/id.cc",
+        "spectator/max_gauge.cc",
+        "spectator/monotonic_counter.cc",
+        "spectator/monotonic_sampled.cc",
+        "spectator/percentile_buckets.cc",
+        "spectator/registry.cc",
+        "spectator/smile.cc",
+        "spectator/strings.cc",
+        "spectator/string_pool.cc",
+        "spectator/timer.cc",
+    ],
+    hdrs = [
+        "spectator/atomicnumber.h",
+        "spectator/common_refs.h",
+        "spectator/compressed_buffer.h",
+        "spectator/config.h",
+        "spectator/counter.h",
+        "spectator/dist_stats.h",
+        "spectator/dist_summary.h",
+        "spectator/gauge.h",
+        "spectator/gzip.h",
+        "spectator/http_client.h",
+        "spectator/id.h",
+        "spectator/log_entry.h",
+        "spectator/max_gauge.h",
+        "spectator/measurement.h",
+        "spectator/meter.h",
+        "spectator/monotonic_counter.h",
+        "spectator/monotonic_sampled.h",
+        "spectator/percentile_buckets.h",
+        "spectator/percentile_distribution_summary.h",
+        "spectator/percentile_timer.h",
+        "spectator/publisher.h",
+        "spectator/registry.h",
+        "spectator/smile.h",
+        "spectator/strings.h",
+        "spectator/string_intern.h",
+        "spectator/string_pool.h",
+        "spectator/tags.h",
+        "spectator/timer.h",
+        "spectator/util.h",
+        "spectator/version.h",
+        "percentile_bucket_tags.inc",
+        "percentile_bucket_values.inc",
+        "valid_chars.inc",
+        "spectator/detail/perc_policy.h",
+    ],
     deps = [
         ":util",
         "@asio//:asio",
@@ -58,15 +89,16 @@ cc_library(
         "@curl",
         "@com_github_cyan4973_xxhash//:xxhash",
         "@net_zlib//:zlib",
-        ],
-    visibility = ["//visibility:public"])
+    ],
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "dummy_cfg",
     srcs = ["spectator/sample_config.cc"],
     deps = [":spectator"],
-    visibility = ["//visibility:public"])
-
+    visibility = ["//visibility:public"],
+)
 
 cc_binary(
     name = "gen_perc_bucket_tags",
@@ -112,8 +144,12 @@ genrule(
 
 cc_test(
     name = "spectator_test",
-    srcs = glob(["spectator/*test.cc", 
-                 "spectator/http_server.*", "spectator/test_utils.*", "bin/test_main.cc"]),
+    srcs = glob([
+        "spectator/*test.cc",
+        "spectator/http_server.*",
+        "spectator/test_utils.*",
+        "bin/test_main.cc",
+    ]),
     deps = [
         ":spectator",
         ":dummy_cfg",
@@ -124,26 +160,39 @@ cc_test(
 
 cc_test(
     name = "to_valid_chars",
-    srcs = ["bench/to_valid_bench.cc",],
-    deps = [ "@com_google_benchmark//:benchmark", ]
+    srcs = ["bench/to_valid_bench.cc"],
+    deps = ["@com_google_benchmark//:benchmark"],
 )
 
 cc_test(
     name = "tags_bench",
-    srcs = ["bench/bench_tags.cc",],
+    srcs = ["bench/bench_tags.cc"],
     deps = [
         ":spectator",
         "@com_google_benchmark//:benchmark",
-      ]
-    )
+    ],
+)
 
 cc_library(
     name = "spectatord",
-    srcs = ["server/spectatord.cc", "util/logger.cc",
-            "server/local_server.cc", "server/udp_server.cc", "server/proc_utils.cc"],
-    hdrs = ["util/files.h", "server/expiring_cache.h", "server/spectatord.h", "util/logger.h",
-            "server/udp_server.h", "server/local_server.h",
-            "server/handler.h", "server/local.h", "server/proc_utils.h"],
+    srcs = [
+        "server/spectatord.cc",
+        "util/logger.cc",
+        "server/local_server.cc",
+        "server/udp_server.cc",
+        "server/proc_utils.cc",
+    ],
+    hdrs = [
+        "util/files.h",
+        "server/expiring_cache.h",
+        "server/spectatord.h",
+        "util/logger.h",
+        "server/udp_server.h",
+        "server/local_server.h",
+        "server/handler.h",
+        "server/local.h",
+        "server/proc_utils.h",
+    ],
     deps = [
         ":spectator",
         "@asio//:asio",
@@ -215,22 +264,26 @@ cc_binary(
     local_defines = select({
         "@bazel_tools//src/conditions:linux_x86_64": ["BACKWARD_HAS_BFD=1"],
         "//conditions:default": [],
-        }),
+    }),
     malloc = memory_allocator,
     linkopts = select({
         "@bazel_tools//src/conditions:linux_x86_64": [
-            "/usr/lib/x86_64-linux-gnu/libbfd.a", "/usr/lib/x86_64-linux-gnu/libiberty.a", "-ldl"],
+            "/usr/lib/x86_64-linux-gnu/libbfd.a",
+            "/usr/lib/x86_64-linux-gnu/libiberty.a",
+            "-ldl",
+        ],
         "//conditions:default": [],
-        }),
+    }),
     includes = ["server"],
     deps = [
         ":spectatord",
         "@com_google_absl//absl/flags:parse",
         "@com_github_gabime_spdlog//:spdlog",
-        "@com_github_bombela_backward//:backward",] + select({
-        ":nflx_internal": [ "@nflx_spectator_cfg//:spectator_cfg" ],
+        "@com_github_bombela_backward//:backward",
+    ] + select({
+        ":nflx_internal": ["@nflx_spectator_cfg//:spectator_cfg"],
         "//conditions:default": [":dummy_cfg"],
-        })
+    }),
 )
 
 cc_binary(

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -72,7 +72,8 @@ ABSL_FLAG(bool, debug, false,
           "Debug spectatord. All values will be sent to a dev aggregator and "
           "dropped.");
 ABSL_FLAG(bool, verbose, false, "Use verbose logging");
-ABSL_FLAG(bool, trace, false, "Trace http requests");
+ABSL_FLAG(bool, verbose_http, false,
+          "Output debugging info about http requests");
 ABSL_FLAG(bool, enable_statsd, false, "Enable statsd support");
 ABSL_FLAG(absl::Duration, meter_ttl, absl::Minutes(15),
           "Meter ttl: expire meters after this period of inactivity");
@@ -100,8 +101,8 @@ int main(int argc, char** argv) {
     cfg->uri =
         "http://atlas-aggr-dev.us-east-1.ieptest.netflix.net/api/v4/update";
   }
-  if (absl::GetFlag(FLAGS_trace)) {
-    cfg->trace_http = true;
+  if (absl::GetFlag(FLAGS_verbose_http)) {
+    cfg->verbose_http = true;
   }
   cfg->meter_ttl = absl::GetFlag(FLAGS_meter_ttl);
   auto spectator_logger = GetLogger("spectator");

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -35,7 +35,7 @@ class Config {
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
   std::string uri;
-  bool trace_http = false;
+  bool verbose_http = false;
 
   // sub-classes can override this method implementing custom logic
   // that can disable publishing under certain conditions

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -1,6 +1,7 @@
 #include "http_client.h"
 #include "gzip.h"
 #include "log_entry.h"
+#include "version.h"
 
 #include <algorithm>
 #include <utility>
@@ -27,7 +28,6 @@ class CurlHeaders {
 
 namespace {
 
-constexpr const char* const kUserAgent = "spectator-cpp/1.0";
 size_t curl_ignore_output_fun(char* /*unused*/, size_t size, size_t nmemb,
                               void* /*unused*/) {
   return size * nmemb;
@@ -59,7 +59,8 @@ size_t curl_capture_headers_fun(char* contents, size_t size, size_t nmemb,
 class CurlHandle {
  public:
   CurlHandle() noexcept : handle_{curl_easy_init()} {
-    curl_easy_setopt(handle_, CURLOPT_USERAGENT, kUserAgent);
+    auto user_agent = fmt::format("spectatord/{}", VERSION);
+    curl_easy_setopt(handle_, CURLOPT_USERAGENT, user_agent.c_str());
   }
 
   CurlHandle(const CurlHandle&) = delete;
@@ -219,7 +220,7 @@ HttpResponse HttpClient::perform(const char* method, const std::string& url,
     curl.capture_headers();
   }
 
-  if (config_.trace_requests) {
+  if (config_.verbose_requests) {
     curl.trace_requests();
   }
   auto curl_res = curl.perform();

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -20,7 +20,7 @@ struct HttpClientConfig {
   bool compress;
   bool read_headers;
   bool read_body;
-  bool trace_requests;
+  bool verbose_requests;
 };
 
 using HttpHeaders = std::unordered_map<std::string, std::string>;

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -251,7 +251,7 @@ class Publisher {
       connect_timeout = absl::Seconds(2);
     }
     return HttpClientConfig{connect_timeout, read_timeout, true,
-                            false,           true,         cfg.trace_http};
+                            false,           true,         cfg.verbose_http};
   }
 
   std::pair<size_t, size_t> handle_aggr_response(

--- a/spectator/version.h
+++ b/spectator/version.h
@@ -1,0 +1,1 @@
+static constexpr const char* VERSION = "VERSION";

--- a/tools/generate_version.sh
+++ b/tools/generate_version.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+VERSION=`git describe --tags --always || echo Unknown`
+
+echo static constexpr const char* VERSION = \"$VERSION\"\;


### PR DESCRIPTION
It makes it easier to distinguish among HTTP requests, esp. when
originating from the same host.

In addition rename the `--trace` option to `--verbose_http`