### PR TITLE
Fix tags has/at functionality

### DIFF
--- a/spectator/counter.cc
+++ b/spectator/counter.cc
@@ -11,7 +11,7 @@ void Counter::Measure(Measurements* results) const noexcept {
   if (count > 0) {
     if (!count_id_) {
       count_id_ =
-          std::make_unique<Id>(Id::WithDefaultStat(MeterId(), refs().count()));
+          std::make_unique<Id>(MeterId().WithDefaultStat(refs().count()));
     }
     results->emplace_back(*count_id_, count);
   }

--- a/spectator/gauge.cc
+++ b/spectator/gauge.cc
@@ -35,8 +35,7 @@ void Gauge::Measure(Measurements* results, int64_t now) const noexcept {
     return;
   }
   if (!gauge_id_) {
-    gauge_id_ =
-        std::make_unique<Id>(Id::WithDefaultStat(MeterId(), refs().gauge()));
+    gauge_id_ = std::make_unique<Id>(MeterId().WithDefaultStat(refs().gauge()));
   }
   results->emplace_back(*gauge_id_, value);
 }

--- a/spectator/id.h
+++ b/spectator/id.h
@@ -35,11 +35,11 @@ class Id {
 
   Id WithStat(StrRef stat) const { return WithTag(refs().statistic(), stat); };
 
-  static Id WithDefaultStat(Id baseId, StrRef stat) {
-    if (baseId.GetTags().has(refs().statistic())) {
-      return baseId;
+  Id WithDefaultStat(StrRef stat) const {
+    if (tags_.has(refs().statistic())) {
+      return *this;
     }
-    return baseId.WithStat(stat);
+    return WithStat(stat);
   }
 
   friend std::ostream& operator<<(std::ostream& os, const Id& id) {

--- a/spectator/tags.h
+++ b/spectator/tags.h
@@ -127,14 +127,14 @@ class Tags {
     const auto* it = std::lower_bound(
         begin(), end(), key,
         [](const Tag& tag, const StrRef& k) { return tag.key < k; });
-    return it != end();
+    return it != end() && it->key == key;
   }
 
   [[nodiscard]] StrRef at(const StrRef& key) const {
     const auto* it = std::lower_bound(
         begin(), end(), key,
         [](const Tag& tag, const StrRef& k) { return tag.key < k; });
-    if (it == end()) {
+    if (it == end() || it->key != key) {
       return {};
     }
     return it->value;


### PR DESCRIPTION
We were mistakingly comparing to the `end()` iterator for
found/not-found functionality in tags but since we switched
to a sorted array implementation we need to verify that
the iterator points to the actual key in addition to comparing
to the end.