### PR TITLE
User specified statistic for monotonic counters

### DIFF
--- a/spectator/monotonic_counter.cc
+++ b/spectator/monotonic_counter.cc
@@ -24,7 +24,8 @@ void MonotonicCounter::Measure(Measurements* results) const noexcept {
                     std::memory_order_relaxed);
   if (delta > 0) {
     if (!count_id_) {
-      count_id_ = std::make_unique<Id>(MeterId().WithStat(refs().count()));
+      count_id_ =
+          std::make_unique<Id>(MeterId().WithDefaultStat(refs().count()));
     }
     results->emplace_back(*count_id_, delta);
   }

--- a/spectator/monotonic_counter_test.cc
+++ b/spectator/monotonic_counter_test.cc
@@ -6,7 +6,7 @@ namespace {
 
 using spectator::refs;
 
-spectator::MonotonicCounter getMonotonicCounter(std::string_view name) {
+auto getMonotonicCounter(std::string_view name) -> spectator::MonotonicCounter {
   return spectator::MonotonicCounter(spectator::Id::Of(name));
 }
 
@@ -77,6 +77,19 @@ TEST(MonotonicCounter, Measure) {
   c.Measure(&measures);
   EXPECT_TRUE(measures.empty())
       << "MonotonicCounters should not report delta=0";
+}
+
+TEST(MonotonicCounter, DefaultStatistic) {
+  spectator::Measurements measures;
+  auto c = spectator::MonotonicCounter(
+      spectator::Id::Of("foo", {{"statistic", "totalAmount"}}));
+  c.Set(42);
+  c.Measure(&measures);
+  c.Set(84.0);
+  c.Measure(&measures);
+  auto id = spectator::Id::Of("foo", {{"statistic", "totalAmount"}});
+  std::vector<spectator::Measurement> expected({{id, 42.0}});
+  EXPECT_EQ(expected, measures);
 }
 
 TEST(MonotonicCounter, Update) {


### PR DESCRIPTION
Previously we were ignoring the statistic tag provided by the user and
always using count. This change makes it consistent with the behavior of
regular counters.