### PR TITLE
Report the uptime for the spectatord process

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
         "spectator/timer.cc",
     ],
     hdrs = [
+        "spectator/age_gauge.h",
         "spectator/atomicnumber.h",
         "spectator/common_refs.h",
         "spectator/compressed_buffer.h",

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -312,6 +312,7 @@ static void prepare_socket_path(const std::string& socket_path) {
 
 void Server::Start() {
   auto logger = Logger();
+  registry_->GetAgeGauge("spectatord.uptime")->UpdateLastSuccess();
 
   logger->info("Starting janitorial tasks");
   upkeep_thread_ = std::thread(&Server::upkeep, this);

--- a/spectator/age_gauge.h
+++ b/spectator/age_gauge.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "meter.h"
+#include <atomic>
+
+namespace spectator {
+
+class AgeGauge : public Meter {
+ public:
+  explicit AgeGauge(Id id) noexcept : Meter{std::move(id)}, last_success_{0} {}
+
+  void Measure(Measurements* results) const noexcept {
+    if (!gauge_id_) {
+      gauge_id_ =
+          std::make_unique<Id>(MeterId().WithDefaultStat(refs().gauge()));
+    }
+    results->emplace_back(*gauge_id_, Value());
+  }
+
+  void UpdateLastSuccess(int64_t now = absl::GetCurrentTimeNanos()) noexcept {
+    last_success_.store(now, std::memory_order_relaxed);
+  }
+
+  auto GetLastSuccess() const noexcept -> int64_t {
+    return last_success_.load(std::memory_order_relaxed);
+  }
+
+  auto Value(int64_t now = absl::GetCurrentTimeNanos()) const noexcept
+      -> double {
+    auto last_success = GetLastSuccess();
+    return static_cast<double>(now - last_success) / 1e9;
+  }
+
+ private:
+  std::atomic<int64_t> last_success_;
+  mutable std::unique_ptr<Id> gauge_id_;
+};
+
+}  // namespace spectator

--- a/spectator/age_gauge_test.cc
+++ b/spectator/age_gauge_test.cc
@@ -1,0 +1,45 @@
+#include "age_gauge.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using spectator::AgeGauge;
+using spectator::Id;
+
+TEST(AgeGauge, Init) {
+  AgeGauge g{Id::Of("age")};
+  auto now = absl::GetCurrentTimeNanos();
+  // was not successful yet
+  EXPECT_EQ(g.GetLastSuccess(), 0);
+  auto seconds = static_cast<double>(now) / 1e9;
+  EXPECT_DOUBLE_EQ(g.Value(now), seconds);
+}
+
+TEST(AgeGauge, Update) {
+  AgeGauge g{Id::Of("age")};
+  auto now = absl::GetCurrentTimeNanos();
+  g.UpdateLastSuccess(now);
+  EXPECT_DOUBLE_EQ(g.Value(now), 0.0);
+
+  now += 1e9;
+  EXPECT_DOUBLE_EQ(g.Value(now), 1.0);
+}
+
+TEST(AgeGauge, Measure) {
+  AgeGauge g{Id::Of("age")};
+  auto now = absl::GetCurrentTimeNanos();
+  g.UpdateLastSuccess(now);
+
+  spectator::Measurements results;
+  g.Measure(&results);
+  ASSERT_EQ(results.size(), 1);
+
+  auto& m = results.front();
+  EXPECT_EQ(m.id, Id::Of("age", {{"statistic", "gauge"}}));
+
+  // should be close to 0
+  EXPECT_TRUE(m.value > 0.0 && m.value < 0.1);
+}
+
+}  // namespace

--- a/spectator/age_gauge_test.cc
+++ b/spectator/age_gauge_test.cc
@@ -22,7 +22,7 @@ TEST(AgeGauge, Update) {
   g.UpdateLastSuccess(now);
   EXPECT_DOUBLE_EQ(g.Value(now), 0.0);
 
-  now += 1e9;
+  now += int64_t{1000} * 1000 * 1000;
   EXPECT_DOUBLE_EQ(g.Value(now), 1.0);
 }
 

--- a/spectator/http_client_test.cc
+++ b/spectator/http_client_test.cc
@@ -75,7 +75,7 @@ TEST(HttpTest, Post) {
   auto timer_for_req = find_timer(&registry, "ipc.client.call", "200");
   ASSERT_TRUE(timer_for_req != nullptr);
   auto expected_tags =
-      Tags{{"owner", "spectator-cpp"},   {"http.status", "200"},
+      Tags{{"owner", "spectatord"},   {"http.status", "200"},
            {"http.method", "POST"},      {"ipc.status", "success"},
            {"ipc.result", "success"},    {"ipc.endpoint", "/foo"},
            {"ipc.attempt.final", "true"}};
@@ -133,7 +133,7 @@ TEST(HttpTest, PostUncompressed) {
   auto timer_for_req = find_timer(&registry, "ipc.client.call", "200");
   ASSERT_TRUE(timer_for_req != nullptr);
   auto expected_tags =
-      Tags{{"owner", "spectator-cpp"}, {"http.status", "200"},
+      Tags{{"owner", "spectatord"}, {"http.status", "200"},
            {"http.method", "POST"},    {"ipc.status", "success"},
            {"ipc.result", "success"},  {"ipc.attempt", "initial"},
            {"ipc.endpoint", "/foo"},   {"ipc.attempt.final", "true"}};
@@ -181,7 +181,7 @@ TEST(HttpTest, Timeout) {
   ASSERT_TRUE(timer_for_req != nullptr);
 
   auto expected_tags =
-      Tags{{"owner", "spectator-cpp"}, {"http.status", "-1"},
+      Tags{{"owner", "spectatord"}, {"http.status", "-1"},
            {"ipc.result", "failure"},  {"ipc.status", "timeout"},
            {"ipc.attempt", "initial"}, {"ipc.attempt.final", "true"},
            {"ipc.endpoint", "/foo"},   {"http.method", "POST"}};
@@ -262,7 +262,7 @@ TEST(HttpTest, Get) {
 
   spectator::Tags timer_tags{
       {"http.status", "200"},    {"ipc.attempt", "initial"},
-      {"ipc.result", "success"}, {"owner", "spectator-cpp"},
+      {"ipc.result", "success"}, {"owner", "spectatord"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", "GET"},    {"ipc.endpoint", "/get"}};
   auto timer_id = Id::Of("ipc.client.call", std::move(timer_tags));
@@ -294,12 +294,12 @@ TEST(HttpTest, Get503) {
 
   spectator::Tags err_timer_tags{
       {"http.status", "503"},       {"ipc.attempt", "initial"},
-      {"ipc.result", "failure"},    {"owner", "spectator-cpp"},
+      {"ipc.result", "failure"},    {"owner", "spectatord"},
       {"ipc.status", "http_error"}, {"ipc.attempt.final", "false"},
       {"http.method", "GET"},       {"ipc.endpoint", "/get503"}};
   spectator::Tags success_timer_tags{
       {"http.status", "200"},    {"ipc.attempt", "second"},
-      {"ipc.result", "success"}, {"owner", "spectator-cpp"},
+      {"ipc.result", "success"}, {"owner", "spectatord"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", "GET"},    {"ipc.endpoint", "/get503"}};
   auto err_id = Id::Of("ipc.client.call", std::move(err_timer_tags));
@@ -336,7 +336,7 @@ void test_method_header(const std::string& method) {
 
   spectator::Tags timer_tags{
       {"http.status", "200"},    {"ipc.attempt", "initial"},
-      {"ipc.result", "success"}, {"owner", "spectator-cpp"},
+      {"ipc.result", "success"}, {"owner", "spectatord"},
       {"ipc.status", "success"}, {"ipc.attempt.final", "true"},
       {"http.method", method},   {"ipc.endpoint", "/getheader"}};
   auto timer_id = Id::Of("ipc.client.call", std::move(timer_tags));

--- a/spectator/log_entry.h
+++ b/spectator/log_entry.h
@@ -12,7 +12,7 @@ class LogEntry {
            const std::string& url)
       : registry_{registry},
         start_{absl::Now()},
-        id_{Id::Of("ipc.client.call", {{"owner", "spectator-cpp"},
+        id_{Id::Of("ipc.client.call", {{"owner", "spectatord"},
                                        {"ipc.endpoint", PathFromUrl(url)},
                                        {"http.method", method},
                                        {"http.status", "-1"}})} {}

--- a/spectator/monotonic_counter_test.cc
+++ b/spectator/monotonic_counter_test.cc
@@ -1,5 +1,5 @@
-#include "../spectator/monotonic_counter.h"
-#include "../spectator/common_refs.h"
+#include "common_refs.h"
+#include "monotonic_counter.h"
 #include <gtest/gtest.h>
 
 namespace {

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -25,6 +25,15 @@ auto Registry::GetLogger() const noexcept -> Registry::logger_ptr {
   return logger_;
 }
 
+auto Registry::GetAgeGauge(Id id) noexcept -> std::shared_ptr<AgeGauge> {
+  return all_meters_.insert_age_gauge(std::move(id));
+}
+
+auto Registry::GetAgeGauge(std::string_view name, Tags tags) noexcept
+    -> std::shared_ptr<AgeGauge> {
+  return GetAgeGauge(Id::Of(name, std::move(tags)));
+}
+
 auto Registry::GetCounter(Id id) noexcept -> std::shared_ptr<Counter> {
   return all_meters_.insert_counter(std::move(id));
 }

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -2,6 +2,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
+#include "age_gauge.h"
 #include "config.h"
 #include "counter.h"
 #include "dist_summary.h"
@@ -209,6 +210,10 @@ class Registry {
   auto GetMonotonicCounter(Id id) noexcept -> std::shared_ptr<MonotonicCounter>;
   auto GetMonotonicCounter(std::string_view name, Tags tags = {}) noexcept
       -> std::shared_ptr<MonotonicCounter>;
+
+  auto GetAgeGauge(Id id) noexcept -> std::shared_ptr<AgeGauge>;
+  auto GetAgeGauge(std::string_view name, Tags tags = {}) noexcept
+      -> std::shared_ptr<AgeGauge>;
 
   auto GetMonotonicSampled(Id id) noexcept -> std::shared_ptr<MonotonicSampled>;
   auto GetMonotonicSampled(std::string_view name, Tags tags = {}) noexcept

--- a/spectator/registry_test.cc
+++ b/spectator/registry_test.cc
@@ -1,4 +1,4 @@
-#include "../spectator/registry.h"
+#include "registry.h"
 #include "test_utils.h"
 #include <fmt/ostream.h>
 #include <gtest/gtest.h>
@@ -9,6 +9,13 @@ using spectator::Id;
 using spectator::Registry;
 using spectator::Tags;
 using spectatord::Logger;
+
+TEST(Registry, AgeGauge) {
+  Registry r{GetConfiguration(), spectatord::Logger()};
+  auto g = r.GetAgeGauge("foo");
+  g->UpdateLastSuccess();
+  EXPECT_TRUE(g->Value() > 0.0);
+}
 
 TEST(Registry, Counter) {
   Registry r{GetConfiguration(), spectatord::Logger()};


### PR DESCRIPTION
This adds an 'age gauge' metric that reports the number of seconds the
spectatord process has been running. This can be used to track restarts
due to various causes