### PR TITLE
Periodically check we are actively working

### DIFF
--- a/server/spectatord.h
+++ b/server/spectatord.h
@@ -44,6 +44,7 @@ class Server {
   std::optional<std::string> parse_lines(char* buffer, const handler_t& parser);
   std::optional<std::string> parse_line(const char* buffer);
   std::optional<std::string> parse_statsd_line(const char* buffer);
+  void ensure_not_stuck();
 
  protected:
   std::optional<std::string> parse(char* buffer);

--- a/spectator/http_client_test.cc
+++ b/spectator/http_client_test.cc
@@ -75,7 +75,7 @@ TEST(HttpTest, Post) {
   auto timer_for_req = find_timer(&registry, "ipc.client.call", "200");
   ASSERT_TRUE(timer_for_req != nullptr);
   auto expected_tags =
-      Tags{{"owner", "spectatord"},   {"http.status", "200"},
+      Tags{{"owner", "spectatord"},      {"http.status", "200"},
            {"http.method", "POST"},      {"ipc.status", "success"},
            {"ipc.result", "success"},    {"ipc.endpoint", "/foo"},
            {"ipc.attempt.final", "true"}};
@@ -133,10 +133,10 @@ TEST(HttpTest, PostUncompressed) {
   auto timer_for_req = find_timer(&registry, "ipc.client.call", "200");
   ASSERT_TRUE(timer_for_req != nullptr);
   auto expected_tags =
-      Tags{{"owner", "spectatord"}, {"http.status", "200"},
-           {"http.method", "POST"},    {"ipc.status", "success"},
-           {"ipc.result", "success"},  {"ipc.attempt", "initial"},
-           {"ipc.endpoint", "/foo"},   {"ipc.attempt.final", "true"}};
+      Tags{{"owner", "spectatord"},   {"http.status", "200"},
+           {"http.method", "POST"},   {"ipc.status", "success"},
+           {"ipc.result", "success"}, {"ipc.attempt", "initial"},
+           {"ipc.endpoint", "/foo"},  {"ipc.attempt.final", "true"}};
 
   const auto& actual_tags = timer_for_req->MeterId().GetTags();
   EXPECT_EQ(expected_tags, actual_tags);
@@ -181,7 +181,7 @@ TEST(HttpTest, Timeout) {
   ASSERT_TRUE(timer_for_req != nullptr);
 
   auto expected_tags =
-      Tags{{"owner", "spectatord"}, {"http.status", "-1"},
+      Tags{{"owner", "spectatord"},    {"http.status", "-1"},
            {"ipc.result", "failure"},  {"ipc.status", "timeout"},
            {"ipc.attempt", "initial"}, {"ipc.attempt.final", "true"},
            {"ipc.endpoint", "/foo"},   {"http.method", "POST"}};

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -272,6 +272,9 @@ class Registry {
   auto DistSummaries() const -> std::vector<const DistributionSummary*> {
     return all_meters_.dist_sums_.get_values();
   }
+  auto GetLastSuccessTime() const -> int64_t {
+    return publisher_.GetLastSuccessTime();
+  }
 
  private:
   std::atomic<bool> should_stop_;


### PR DESCRIPTION
If for any reason we are not able to successfully send metrics in over 1
minute, abort the process. (Hopefully coredumps are enabled and we can
debug further)