### PR TITLE
Do not trap SIGABRT

### DIFF
--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -91,7 +91,11 @@ ABSL_FLAG(PortNumber, statsd_port, PortNumber(8125),
 
 auto main(int argc, char** argv) -> int {
   auto logger = Logger();
-  backward::SignalHandling sh;
+  auto signals = backward::SignalHandling::make_default_signals();
+  // default signals with the exception of SIGABRT
+  signals.erase(std::remove(signals.begin(), signals.end(), SIGABRT),
+                signals.end());
+  backward::SignalHandling sh{signals};
 
   absl::SetProgramUsageMessage(
       "A daemon that listens for metrics and reports them to atlas");

--- a/bin/test_main.cc
+++ b/bin/test_main.cc
@@ -2,7 +2,12 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
-  backward::SignalHandling sh;
+  using backward::SignalHandling;
+  auto signals = SignalHandling::make_default_signals();
+  // default signals with the exception of SIGABRT
+  signals.erase(std::remove(signals.begin(), signals.end(), SIGABRT),
+                signals.end());
+  SignalHandling sh{signals};
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
We've seen this cause some issues in relation to tcmalloc, but just to
be extra safe. We do not attempt to print a stacktrace when we get an
ABRT signal.