### PR TITLE
Fix bug when copying large tag values

### DIFF
--- a/spectator/tags.h
+++ b/spectator/tags.h
@@ -37,6 +37,7 @@ class Tags {
     if (is_large()) {
       // take ownership of the memory
       o.begin_ = nullptr;
+      U.capacity_ = o.U.capacity_;
     } else {
       begin_ = &U.entries_[0];
       std::copy(o.begin(), o.end(), begin());
@@ -45,7 +46,8 @@ class Tags {
 
   Tags(const Tags& o) : size_{o.size_} {
     if (is_large()) {
-      begin_ = static_cast<Tag*>(malloc(sizeof(Tag) * size()));
+      begin_ = static_cast<Tag*>(malloc(sizeof(Tag) * size_));
+      U.capacity_ = size_;
     } else {
       begin_ = &U.entries_[0];
     }
@@ -143,6 +145,10 @@ class Tags {
 
   [[nodiscard]] auto size() const -> size_type { return size_; }
 
+  [[nodiscard]] auto capacity() const -> size_type {
+    return is_large() ? U.capacity_ : kSmallTags;
+  }
+
   [[nodiscard]] auto empty() const -> bool { return size_ == 0; }
 
   [[nodiscard]] auto begin() const -> const_iterator { return begin_; }
@@ -171,7 +177,8 @@ class Tags {
         it = begin() + diff;
       }
 
-      // move all elements one to the right
+      // move all elements to the right to make room
+      // for the new element at position `it`
       std::copy_backward(it, end(), end() + 1);
     } else if (size() == capacity()) {
       reallocate();
@@ -179,10 +186,6 @@ class Tags {
     }
     *it = {k, v};
     ++size_;
-  }
-
-  [[nodiscard]] auto capacity() const -> size_type {
-    return is_large() ? U.capacity_ : kSmallTags;
   }
 
   auto reallocate() -> void {

--- a/spectator/tags_test.cc
+++ b/spectator/tags_test.cc
@@ -38,11 +38,72 @@ TEST(Tags, At) {
   for (auto i = 0; i < 16; ++i) {
     t.add(fmt::format("K{}", i), fmt::format("V{}", i));
   }
+  t.add("A000", "V000");
 
+  using spectator::intern_str;
   for (auto i = 15; i >= 0; --i) {
-    auto k = spectator::intern_str(fmt::format("K{}", i));
-    auto v = spectator::intern_str(fmt::format("V{}", i));
+    auto k = intern_str(fmt::format("K{}", i));
+    auto v = intern_str(fmt::format("V{}", i));
     EXPECT_EQ(t.at(k), v);
   }
+  auto k = intern_str("A000");
+  auto v = intern_str("V000");
+  EXPECT_EQ(t.at(k), v);
 }
+
+// add n tags of the form K<num> = V<num>
+auto prepare_tags(Tags* tags, int n) -> void {
+  for (auto i = 0; i < 16; ++i) {
+    tags->add(fmt::format("K{}", i), fmt::format("V{}", i));
+  }
+}
+
+auto verify_tags(const Tags& tags, int n) -> void {
+  ASSERT_TRUE(tags.capacity() >= n);
+  for (auto i = n - 1; i >= 0; --i) {
+    auto k = spectator::intern_str(fmt::format("K{}", i));
+    auto v = spectator::intern_str(fmt::format("V{}", i));
+    EXPECT_EQ(tags.at(k), v);
+  }
+}
+
+TEST(Tags, Copy) {
+  for (auto size = 1; size < 16; ++size) {
+    Tags t;
+    prepare_tags(&t, size);
+
+    Tags t2{t};
+    ASSERT_EQ(t2.size(), t.size());
+    ASSERT_TRUE(t2.capacity() >= t2.size());
+    ASSERT_TRUE(t2.capacity() >= t.size());
+    verify_tags(t, size);
+  }
+}
+
+TEST(Tags, Copy_Add) {
+  using spectator::intern_str;
+  for (auto size = 15; size < 16; ++size) {
+    Tags t;
+    prepare_tags(&t, size);
+    Tags t2{t};
+
+    // add to the end
+    t2.add(fmt::format("K{}", size), fmt::format("V{}", size));
+
+    // add to the beginning
+    t2.add("A000", "V000");
+
+    // add to the middle
+    t2.add(fmt::format("K{}-", size), "V000");
+
+    verify_tags(t2, size + 1);
+    auto k = intern_str("A000");
+    auto v = intern_str("V000");
+    EXPECT_EQ(t2.at(k), v);
+
+    k = intern_str(fmt::format("K{}-", size + 1));
+    EXPECT_EQ(t2.at(k), t.at(v));
+  }
+}
+
 }  // namespace


### PR DESCRIPTION
We are using a small buffer optimization for tags where we do not need
to allocate memory if the number of tags is <= 8. We are saving memory
by reusing the array of tags to store the capacity when the tags live on
the heap. However we were not initializing the capacity correctly when
copying/moving from another large Tags value.