### PR TITLE
add --enable_socket flag to allow for disabling the unix socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-bazel-*
-build-*
-.idea/
-.vscode/
 .clwb
-build
-spectatord
-compile_commands.json
+.idea/
 .newt-cache/
+.vscode/
+Dockerfile-e
+bazel-*
+build
+build-*
+compile_commands.json
+spectatord

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM BASEOS_IMAGE
+MAINTAINER Netflix Observability Engineering
+
+RUN sudo apt update
+RUN sudo apt -y install software-properties-common
+RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+RUN echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' | sudo tee /etc/apt/sources.list.d/bazel.list
+RUN sudo apt update
+RUN sudo apt -y install bazel-3.7.2 binutils-dev g++-10 libiberty-dev
+RUN sudo ln -s /usr/bin/bazel-3.7.2 /usr/bin/bazel

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+SPECTATORD_IMAGE="spectatord/builder:latest"
+SPECTATORD_IMAGE_ID=$(docker images --quiet $SPECTATORD_IMAGE)
+
+if [[ -z "$SPECTATORD_IMAGE_ID" ]]; then
+  if [[ -z "$BASEOS_IMAGE" ]]; then
+    echo "set BASEOS_IMAGE to a reasonable value, such as an Ubuntu LTS version" && exit 1
+  fi
+
+  sed -i -e "s,BASEOS_IMAGE,$BASEOS_IMAGE,g" Dockerfile
+  docker build --tag spectatord/builder:latest . || exit 1
+  git checkout Dockerfile
+else
+  echo "using image $SPECTATORD_IMAGE $SPECTATORD_IMAGE_ID"
+fi
+
+if [[ "$1" == "shell" ]]; then
+  docker run --rm --interactive --tty --mount type=bind,source="$(pwd)",target=/src $SPECTATORD_IMAGE /bin/bash
+  exit 0
+fi
+
+# recommend 8GB RAM allocation for docker desktop, to allow the test build with asan to succeed
+cat >start-build <<EOF
+echo "-- build tests with address sanitizer enabled"
+bazel --output_user_root=/storage/bazel build --config=asan spectator_test spectatord_test
+
+echo "-- run tests"
+bazel-bin/spectator_test && bazel-bin/spectatord_test
+
+echo "-- build optimized daemon"
+bazel --output_user_root=/storage/bazel build --compilation_mode=opt spectatord_main
+
+echo "-- check shared library dependencies"
+ldd bazel-bin/spectatord_main || true
+
+echo "-- copy binary to local filesystem"
+cp -p bazel-bin/spectatord_main spectatord
+EOF
+
+chmod 755 start-build
+docker run --rm --tty --mount type=bind,source="$(pwd)",target=/src $SPECTATORD_IMAGE /bin/bash -c "cd src && ./start-build"
+rm ./start-build

--- a/server/spectatord.h
+++ b/server/spectatord.h
@@ -10,7 +10,7 @@ namespace spectatord {
 
 class Server {
  public:
-  Server(int port_number, int statsd_port_number, std::string socket_path,
+  Server(int port_number, std::optional<int> statsd_port_number, std::optional<std::string> socket_path,
          spectator::Registry* registry);
   Server(const Server&) = delete;
   Server(Server&&) = delete;
@@ -24,8 +24,8 @@ class Server {
 
  private:
   int port_number_;
-  int statsd_port_number_;
-  std::string socket_path_;
+  std::optional<int> statsd_port_number_;
+  std::optional<std::string> socket_path_;
   spectator::Registry* registry_;
   std::shared_ptr<spectator::Counter> parsed_count_;
   std::shared_ptr<spectator::Counter> parse_errors_;


### PR DESCRIPTION
We have some teams that would prefer to run this service without the UNIX
domain socket. To preserve backward compatibility, the default value of this
flag is true.

The handling of enable flags has been adjusted slightly, so that optionals
are used, which makes the code a little easier to read when passing these
values around.

A few functions which are no longer needed since the switch to the Abseil
flags library have been removed.

A Dockerfile and build script have been added to the project, to provide a
reproducible means of running builds locally. To use this build script, you
must provide a BASEOS_IMAGE environment variable, which should resolve to a
reasonable image, such as an Ubuntu LTS version.

In order to allow the build to complete successfully, it is recommended to
configure Docker Desktop with 8GB RAM
