### PR TITLE
Age Gauge Limit Flag

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -207,6 +207,8 @@ cc_test(
         "bin/test_main.cc",
         "server/proc_utils_test.cc",
         "server/spectatord_test.cc",
+        "spectator/test_utils.h",
+        "spectator/test_utils.cc"
     ],
     data = glob(["test-resources/*"]),
     deps = [

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -18,7 +18,7 @@ class Config {
 
   Config(std::map<std::string, std::string> c_tags, int read_to_ms,
          int connect_to_ms, int batch_sz, int freq_ms, int exp_freq_ms,
-         int meter_ttl_ms, std::string publish_uri)
+         int meter_ttl_ms, size_t age_gauge_limit, std::string publish_uri)
       : common_tags{std::move(c_tags)},
         read_timeout{absl::Milliseconds(read_to_ms)},
         connect_timeout{absl::Milliseconds(connect_to_ms)},
@@ -26,6 +26,7 @@ class Config {
         frequency{absl::Milliseconds(freq_ms)},
         expiration_frequency{absl::Milliseconds(exp_freq_ms)},
         meter_ttl{absl::Milliseconds(meter_ttl_ms)},
+        age_gauge_limit{age_gauge_limit},
         uri{std::move(publish_uri)} {}
   std::map<std::string, std::string> common_tags;
   absl::Duration read_timeout;
@@ -34,6 +35,7 @@ class Config {
   absl::Duration frequency;
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
+  size_t age_gauge_limit{};
   std::string uri;
   bool verbose_http = false;
 

--- a/spectator/config_test.cc
+++ b/spectator/config_test.cc
@@ -8,5 +8,6 @@ TEST(Config, Constructor) {
   // just make sure that our documented Config constructor works
   spectator::Config config{
       common_tags, kDefault, kDefault, kDefault,
-      kDefault,    kDefault, kDefault, "http://example.org/api/v1/publish"};
+      kDefault,    kDefault, kDefault, kDefault,
+      "http://example.org/api/v1/publish"};
 }

--- a/spectator/test_utils.h
+++ b/spectator/test_utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../spectator/registry.h"
+#include "registry.h"
 #include <map>
 #include <string>
 #include <vector>
@@ -43,6 +43,11 @@ inline auto my_gauges(const spectator::Registry& registry)
   return filter_my_meters(registry.Gauges());
 }
 
+inline auto my_age_gauges(const spectator::Registry& registry)
+-> std::vector<const spectator::AgeGauge*> {
+  return filter_my_meters(registry.AgeGauges());
+}
+
 inline auto my_max_gauges(const spectator::Registry& registry)
     -> std::vector<const spectator::MaxGauge*> {
   return filter_my_meters(registry.MaxGauges());
@@ -55,6 +60,7 @@ inline auto my_mono_counters(const spectator::Registry& registry)
 
 inline auto my_meters_size(const spectator::Registry& registry) -> size_t {
   return my_timers(registry).size() + my_counters(registry).size() +
-         my_gauges(registry).size() + my_max_gauges(registry).size() +
-         my_ds(registry).size() + my_mono_counters(registry).size();
+         my_gauges(registry).size() + my_age_gauges(registry).size() +
+         my_max_gauges(registry).size() + my_ds(registry).size() +
+         my_mono_counters(registry).size();
 }


### PR DESCRIPTION
As discussed in #23, this PR implements a limit on the maximum number of age gauges that may be reported from a `spectatord` process.

The purpose of this feature is to limit a potential source of memory leaks for long-running `spectatord` processes where the tags associated with an age gauge vary over time. The limit defaults to 1000 and we do not think that most users will hit this limit on a per-node basis. The limit is customizable with the `--age_gauge_limit` flag, in the event that users need to adjust this setting for their particular service.