### PR TITLE
fix local server startup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,8 @@ fi
 
 # recommend 8GB RAM allocation for docker desktop, to allow the test build with asan to succeed
 cat >start-build <<EOF
-echo "-- build tests with address sanitizer enabled"
-bazel --output_user_root=/storage/bazel build --config=asan spectator_test spectatord_test
-
-echo "-- run tests"
-bazel-bin/spectator_test && bazel-bin/spectatord_test
+echo "-- run tests with address sanitizer enabled"
+bazel --output_user_root=/storage/bazel test --config=asan spectator_test spectatord_test
 
 echo "-- build optimized daemon"
 bazel --output_user_root=/storage/bazel build --compilation_mode=opt spectatord_main
@@ -35,6 +32,7 @@ echo "-- check shared library dependencies"
 ldd bazel-bin/spectatord_main || true
 
 echo "-- copy binary to local filesystem"
+rm -f spectatord
 cp -p bazel-bin/spectatord_main spectatord
 EOF
 

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -346,11 +346,12 @@ void Server::Start() {
     logger->info("statsd support is not enabled");
   }
 
+  std::unique_ptr<LocalServer> local_server;
   if (socket_path_) {
     prepare_socket_path(*socket_path_);
-    LocalServer dgram_local{io_context, *socket_path_, parser};
-    dgram_local.Start();
+    local_server = std::make_unique<LocalServer>(io_context, *socket_path_, parser);
     logger->info("Starting local server (dgram) on socket {}", *socket_path_);
+    local_server->Start();
   } else {
     logger->info("unix socket support is not enabled");
   }


### PR DESCRIPTION
This bug was introduced with the PR that added the --enable_unix_socket
flag. The creation of the server was moved into the scope of an if
statement, which meant that it was not available to the io context
when it started, which produced the following errors:

[info] Starting local server (dgram) on socket /run/spectatord/spectatord.unix
[error] Error receiving: 125: Operation aborted.
[error] Error receiving: 9: Bad file descriptor

This change follows the model of the statsd server, by declaring a unique
pointer to the local server outside the scope of the if statement.