### PR TITLE
update build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
-.clwb
+.cache/
+.clwb/
 .idea/
 .newt-cache/
 .vscode/
 Dockerfile-e
 bazel-*
-build
-build-*
-compile_commands.json
 spectatord

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM BASEOS_IMAGE
 MAINTAINER Netflix Observability Engineering
 
 RUN sudo apt update
-RUN sudo apt install -y software-properties-common
+RUN sudo apt install -y curl gnupg software-properties-common
+RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+RUN sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-RUN echo 'deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8' | sudo tee /etc/apt/sources.list.d/bazel.list
 RUN sudo apt update
-RUN sudo apt -y install bazel-3.7.2 binutils-dev g++-10 libiberty-dev
-RUN sudo ln -s /usr/bin/bazel-3.7.2 /usr/bin/bazel
-
-VOLUME /storage
+RUN sudo apt -y install bazel binutils-dev g++-10 libiberty-dev

--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,14 @@ fi
 
 # recommend 8GB RAM allocation for docker desktop, to allow the test build with asan to succeed
 cat >start-build <<EOF
-echo "-- run tests with address sanitizer enabled"
-bazel --output_user_root=/storage/bazel test --config=asan spectator_test spectatord_test
+echo "-- build tests with address sanitizer enabled"
+bazel --output_user_root=.cache build --config=asan spectator_test spectatord_test
+
+echo "-- run tests"
+bazel-bin/spectator_test && bazel-bin/spectatord_test
 
 echo "-- build optimized daemon"
-bazel --output_user_root=/storage/bazel build --compilation_mode=opt spectatord_main
+bazel --output_user_root=.cache build --compilation_mode=opt spectatord_main
 
 echo "-- check shared library dependencies"
 ldd bazel-bin/spectatord_main || true
@@ -37,5 +40,7 @@ cp -p bazel-bin/spectatord_main spectatord
 EOF
 
 chmod 755 start-build
+
 docker run --rm --tty --mount type=bind,source="$(pwd)",target=/src $SPECTATORD_IMAGE /bin/bash -c "cd src && ./start-build"
-rm ./start-build
+
+rm start-build


### PR DESCRIPTION
* Update bazel install steps in the Dockerfile.
* Configure the bazel builds to use a local cache directory, rather than
one in the container, so that downloads and actions are available for
subsequent builds.