### PR TITLE
ensure compressed buffer is finished

### DIFF
--- a/spectator/compressed_buffer.h
+++ b/spectator/compressed_buffer.h
@@ -13,10 +13,12 @@ struct CompressedResult {
 
 class CompressedBuffer {
  public:
-  static constexpr size_t kDefaultChunkSize = 256 * 1024;
+  static constexpr size_t kDefaultChunkSizeInput = 256 * 1024;
   static constexpr size_t kDefaultOutSize = 256 * 1024;
-  explicit CompressedBuffer(size_t chunk_size = kDefaultChunkSize,
-                            size_t out_size = kDefaultOutSize);
+  static constexpr size_t kDefaultChunkSizeOutput = 32 * 1024;
+  explicit CompressedBuffer(size_t chunk_size_input = kDefaultChunkSizeInput,
+                            size_t out_size = kDefaultOutSize,
+                            size_t chunk_size_output = kDefaultChunkSizeOutput);
   CompressedBuffer(const CompressedBuffer&) = delete;
   CompressedBuffer(CompressedBuffer&&) = default;
   auto operator=(const CompressedBuffer&) -> CompressedBuffer& = delete;
@@ -90,14 +92,17 @@ class CompressedBuffer {
  private:
   bool init_{false};
   std::vector<uint8_t> cur_;
-  size_t chunk_size_;
+  size_t chunk_size_input_;
   std::vector<uint8_t> dest_;
+  size_t chunk_size_output_;
   int dest_index_{0};
   z_stream stream;
 
   auto compress(int flush) -> void;
 
   auto maybe_compress() -> void;
+
+  auto deflate_chunk(size_t chunk_size, int flush) -> int;
 };
 
 }  // namespace spectator

--- a/spectator/compressed_buffer_test.cc
+++ b/spectator/compressed_buffer_test.cc
@@ -14,8 +14,10 @@ TEST(CompressedBuffer, Basic) {
   std::string string2(1000, 'b');
   std::string string3(1000, 'c');
 
-  // start with a tiny out to test the resize
-  CompressedBuffer buf{1024, 32};
+  // Small output sizes are to ensure there will not be enough space
+  // to finish the compressed buffer and a resize will be required to
+  // correctly compress the data.
+  CompressedBuffer buf{1024, 32, 32};
   buf.Init();
   buf.Append(string1);
   buf.Append(string2);


### PR DESCRIPTION
Before there was a bug when compress was called with
`Z_FINISH` if the destination buffer was not big enough.
It would only keep looping while `avail_in > 0`. However,
it needs to check for `Z_STREAM_END` to ensure that the
compressed buffer is actually finished.