### PR TITLE
do not abort when disabled

### DIFF
--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -361,15 +361,18 @@ void Server::Start() {
 
 void Server::ensure_not_stuck() {
   auto now = absl::GetCurrentTimeNanos();
+  const auto& cfg = registry_->GetConfig();
   auto elapsed = absl::Nanoseconds(now - registry_->GetLastSuccessTime());
   auto seconds = absl::ToDoubleSeconds(elapsed);
-  if (seconds > 60) {
+
+  if (cfg.is_enabled() && seconds > 60) {
     logger_->error(
         "Too long since we were able to send metrics successfully: {} > 60s. "
         "ABORTING.",
         seconds);
     abort();
   }
+
   logger_->debug("Last batch of metrics was sent successfully {} seconds ago",
                  seconds);
 }

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -316,7 +316,11 @@ class Publisher {
     auto batch_size =
         static_cast<std::vector<Measurement>::difference_type>(cfg.batch_size);
     auto measurements = registry_->Measurements();
+
     if (!cfg.is_enabled() || measurements.empty()) {
+      if (logger->should_log(spdlog::level::trace)) {
+        logger->trace("Skip sending metrics: ATLAS_DISABLED_FILE exists or measurements is empty");
+      }
       return;
     }
 


### PR DESCRIPTION
If an instance had a disabled file defined, then spectatord would never
send metrics, which would cause it to abort every minute and fill up
available disk space with core files.

This change considers whether or not spectatord is enabled when checking the
last time since it was able to send metrics successfully.

Added a trace log for the condition where we skip sending metrics, to make
it more obvious what is happening when verbose logging is enabled.