### PR TITLE
reduce titus error logging

### DIFF
--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -359,6 +359,10 @@ void Server::Start() {
   io_context.run();
 }
 
+// This watchdog is removed from the upkeep loop, because there are many instances
+// in the environment which do not have configurations that allow them to publish
+// metrics. We do not want to fill those disks with core files. The function remains
+// in the codebase, so that we can rapidly re-enable it for debugging.
 void Server::ensure_not_stuck() {
   auto now = absl::GetCurrentTimeNanos();
   const auto& cfg = registry_->GetConfig();
@@ -407,7 +411,6 @@ void Server::upkeep() {
   size_t t_expired = 0;
   while (!should_stop_) {
     auto start = clock::now();
-    ensure_not_stuck();
 
     std::tie(ds_size, ds_expired) = perc_ds_.expire();
     std::tie(t_size, t_expired) = perc_timers_.expire();

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -226,7 +226,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
     curl.trace_requests();
   }
   auto curl_res = curl.perform();
-  auto http_code = 400;
+  int http_code;
 
   if (curl_res != CURLE_OK) {
     logger->error("Failed to {} {}: {}", method, url,
@@ -255,6 +255,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
                      attempt_number + 1);
     }
 
+    http_code = -1;
     entry.set_status_code(-1);
   } else {
     http_code = curl.status_code();

--- a/spectator/http_client_test.cc
+++ b/spectator/http_client_test.cc
@@ -174,7 +174,7 @@ TEST(HttpTest, Timeout) {
                               post_data.c_str(), post_data.length());
   server.stop();
 
-  auto expected_response = HttpResponse{400, ""};
+  auto expected_response = HttpResponse{-1, ""};
   ASSERT_EQ(response.status, expected_response.status);
   ASSERT_EQ(response.raw_body, expected_response.raw_body);
   auto timer_for_req = find_timer(&registry, "ipc.client.call", "-1");
@@ -198,7 +198,7 @@ TEST(HttpTest, ConnectTimeout) {
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   auto response = client.Post(url, "Content-type: application/json", post_data);
 
-  auto expected_response = HttpResponse{400, ""};
+  auto expected_response = HttpResponse{-1, ""};
   ASSERT_EQ(response.status, expected_response.status);
   ASSERT_EQ(response.raw_body, expected_response.raw_body);
 

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -300,6 +300,9 @@ class Publisher {
           num_err = num_measurements;
         }
       }
+    } else if (http_code == -1) {  // connection error or timeout
+      num_err = num_measurements;
+      droppedOther_->Add(num_measurements);
     } else {  // 5xx error
       droppedHttp_->Add(num_measurements);
       num_err = num_measurements;


### PR DESCRIPTION
There are a number of containers which are launched on Titus that do not
have a configuration which allows them to publish metrics. This leads to
two additional sources of noise in that environment:

* HTTP timeouts with three retries will be encountered every 5 seconds
and there will be a failed attempt to parse a non-existent error response.
* Since no metrics are sent, the daemon will abort every minute, leaving
behind core files, which will eventually fill up the disk.

This change removes the `ensure_not_stuck` watchdog from the main upkeep
loop, to prevent the aborts from occurring. We keep the function in the
code, so that we can rapidly re-enable it for snapshot builds, if we need
it for debugging.

For HTTP timeouts, we now set the `http_code` to a `-1` value, which matches
the value we set for metrics. The aggregator response handler covers this
case separately and does not produce additional logs.