### PR TITLE
admin server

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,13 +3,12 @@ Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: true
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: true
@@ -17,12 +16,12 @@ AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
   AfterClass:      false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   false
   AfterNamespace:  false
@@ -36,7 +35,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     80
+ColumnLimit:     100
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
@@ -72,7 +71,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    false
+SortIncludes: Never
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
@@ -87,4 +86,3 @@ Standard:        Auto
 TabWidth:        8
 UseTab:          Never
 ...
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           python3 -V
 
           echo "==== conan ===="
-          pip install conan
+          pip install "conan==1.59.0"
           conan --version
           if [[ ! -f ~/.conan/profiles/default ]]; then conan profile new default --detect; fi
           conan profile update settings.compiler.libcxx=libstdc++11 default
@@ -54,6 +54,8 @@ jobs:
           cd $BUILD_DIR
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build .
+          echo "==== ldd ===="
+          ldd bin/spectatord_main || true
 
       - name: Test spectatord
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(CTest)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+add_subdirectory(admin)
 add_subdirectory(bench)
 add_subdirectory(server)
 add_subdirectory(spectator)
@@ -41,6 +42,7 @@ add_test(
 
 #-- spectatord_test test executable
 add_executable(spectatord_test
+    "admin/admin_server_test.cc"
     "bin/test_main.cc"
     "server/proc_utils_test.cc"
     "server/spectatord_test.cc"
@@ -48,7 +50,7 @@ add_executable(spectatord_test
     "spectator/test_utils.h"
 )
 target_include_directories(spectatord_test PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(spectatord_test spectatord ${CONAN_LIBS})
+target_link_libraries(spectatord_test admin_server spectatord ${CONAN_LIBS})
 add_test(
     NAME spectatord_test
     COMMAND spectatord_test
@@ -67,6 +69,7 @@ if(NFLX_INTERNAL)
     target_link_libraries(spectatord_main
         netflix_cfg
         spectatord
+        admin_server
         ${CONAN_LIBS}
     )
 else()
@@ -74,6 +77,7 @@ else()
     target_link_libraries(spectatord_main
         sample_cfg
         spectatord
+        admin_server
         ${CONAN_LIBS}
     )
 endif()

--- a/admin/CMakeLists.txt
+++ b/admin/CMakeLists.txt
@@ -1,0 +1,9 @@
+#-- admin server library
+add_library(admin_server
+    "admin_server.cc"
+    "admin_server.h"
+)
+target_include_directories(admin_server PRIVATE
+    ${CMAKE_SOURCE_DIR}
+)
+target_link_libraries(admin_server ${CONAN_LIBS})

--- a/admin/admin_server.cc
+++ b/admin/admin_server.cc
@@ -1,0 +1,336 @@
+#include "admin_server.h"
+#include "server/spectatord.h"
+#include "spectator/version.h"
+#include <Poco/JSON/Parser.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <algorithm>
+#include <numeric>
+
+namespace admin {
+
+using namespace Poco::Dynamic;
+using namespace Poco::JSON;
+using namespace Poco::Net;
+
+using admin::AdminServer;
+using admin::RequestHandler;
+using admin::RequestHandlerFactory;
+
+using spectator::Id;
+using spectator::Tags;
+using spectatord::get_measurement;
+
+std::string join(std::vector<std::string> const& strings, const std::string& delimiter) {
+  return std::accumulate(
+      std::next(strings.begin()), strings.end(), strings[0],
+      [&delimiter](const std::string& a, const std::string& b) {
+        return a + delimiter + b;
+      });
+}
+
+void GET_root(HTTPServerRequest& req, HTTPServerResponse& res) {
+  res.setStatus(HTTPResponse::HTTP_OK);
+  res.setContentType("application/json");
+  res.send() << "{"
+             << R"("description": "SpectatorD Admin Server )" << VERSION
+             << R"(",)"
+             << R"("endpoints": [)"
+             << R"("http://)" << req.getHost() << R"(",)"
+             << R"("http://)" << req.getHost() << R"(/config",)"
+             << R"("http://)" << req.getHost() << R"(/config/common_tags",)"
+             << R"("http://)" << req.getHost() << R"(/metrics")"
+             << "]"
+             << "}";
+}
+
+void GET_config(HTTPServerRequest& req, HTTPServerResponse& res,
+                const spectator::Config& config) {
+  Object::Ptr obj = new Object(true);
+
+  Object::Ptr common_tags = new Object(true);
+  for (auto& pair : config.common_tags)
+    common_tags->set(pair.first, pair.second);
+  obj->set("common_tags", common_tags);
+
+  obj->set("read_timeout", ToDoubleMilliseconds(config.read_timeout));
+  obj->set("connect_timeout", ToDoubleMilliseconds(config.connect_timeout));
+  obj->set("batch_size", config.batch_size);
+  obj->set("frequency", ToDoubleMilliseconds(config.frequency));
+  obj->set("expiration_frequency",
+           ToDoubleMilliseconds(config.expiration_frequency));
+  obj->set("meter_ttl", ToDoubleMilliseconds(config.meter_ttl));
+  obj->set("age_gauge_limit", config.age_gauge_limit);
+  obj->set("uri", config.uri);
+
+  res.setStatus(HTTPResponse::HTTP_OK);
+  res.setContentType("application/json");
+  obj->stringify(res.send());
+}
+
+void GET_config_common_tags(HTTPServerRequest& req, HTTPServerResponse& res,
+                            const std::string& allowed_tags) {
+  std::string usage =
+      "To configure SpectatorD common tags, POST a JSON object to this endpoint with "
+      "key-value pairs defining the desired common tags. To delete a tag, set the value "
+      "to an empty string. Attempting to configure any other tags besides the allowed "
+      "set will return an error. Only the following tags may be modified: ";
+  usage += allowed_tags + ".";
+
+  res.setStatus(HTTPResponse::HTTP_OK);
+  res.setContentType("application/json");
+  res.send() << "{" << R"("usage":")" << usage << R"(")" << "}";
+}
+
+void POST_config_common_tags(HTTPServerRequest& req, HTTPServerResponse& res,
+                             std::shared_ptr<spdlog::logger>& logger,
+                             const std::vector<std::string>& allowed_tags,
+                             spectator::Registry& registry) {
+  Parser parser;
+  Var result;
+
+  try {
+     result = parser.parse(req.stream());
+  } catch (Poco::Exception& e) {
+    logger->error("POST /config/common_tags json parse error: {}", e.message());
+    res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+    res.setReason("Bad Request");
+    res.setContentType("application/json");
+    res.send() << R"({"message": "json parse exception"})";
+    return;
+  }
+
+  if (result.type() != typeid(Object::Ptr)) {
+    res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+    res.setReason("Bad Request");
+    res.setContentType("application/json");
+    res.send() << R"({"message": "expected a json object"})";
+    return;
+  }
+
+  Object::Ptr object = result.extract<Object::Ptr>();
+
+  for (auto & it : *object) {
+    if (std::find(allowed_tags.begin(), allowed_tags.end(), it.first) == allowed_tags.end()) {
+      res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+      res.setReason("Bad Request");
+      res.setContentType("application/json");
+      res.send() << R"({"message": "only allowed tags may be set"})";
+      return;
+    }
+    if (it.second.type() != typeid(std::string)) {
+      res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+      res.setReason("Bad Request");
+      res.setContentType("application/json");
+      res.send() << R"({"message": "tag values must be strings"})";
+      return;
+    }
+  }
+
+  for (auto & it : *object) {
+    auto second = it.second.extract<std::string>();
+    if (second.empty()) {
+      logger->info("delete common tag {}", it.first);
+      registry.EraseCommonTag(it.first);
+    } else {
+      logger->info("update common tag {}={}", it.first, second);
+      registry.UpdateCommonTag(it.first, second);
+    }
+  }
+
+  res.setStatus(HTTPResponse::HTTP_OK);
+  res.setContentType("application/json");
+  res.send() << R"({"message": "common tags updated"})";
+}
+
+Poco::SharedPtr<Object> fmt_meter_object(spectator::Meter* meter) {
+  Object::Ptr obj = new Object(true);
+  obj->set("name", fmt::format("{}", meter->MeterId().Name()));
+
+  Object::Ptr tag_obj = new Object(true);
+  for (auto tag_it : meter->MeterId().GetTags()) {
+    tag_obj->set(fmt::format("{}", tag_it.key), fmt::format("{}", tag_it.value));
+  }
+  obj->set("tags", tag_obj);
+
+  return obj;
+}
+
+void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Registry& registry) {
+  Object::Ptr obj = new Object(true);
+
+  Poco::JSON::Array::Ptr age_gauges = new Poco::JSON::Array(true);
+  for (auto it : registry.AgeGauges()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->Value()));
+    age_gauges->add(meter);
+  }
+  obj->set("age_gauges", age_gauges);
+
+  Poco::JSON::Array::Ptr counters = new Poco::JSON::Array(true);
+  for (auto it : registry.Counters()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->Count()));
+    counters->add(meter);
+  }
+  obj->set("counters", counters);
+
+  Poco::JSON::Array::Ptr dist_summaries = new Poco::JSON::Array(true);
+  for (auto it : registry.DistSummaries()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->TotalAmount()));
+    dist_summaries->add(meter);
+  }
+  obj->set("dist_summaries", dist_summaries);
+
+  Poco::JSON::Array::Ptr gauges = new Poco::JSON::Array(true);
+  for (auto it : registry.Gauges()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->Get()));
+    gauges->add(meter);
+  }
+  obj->set("gauges", gauges);
+
+  Poco::JSON::Array::Ptr max_gauges = new Poco::JSON::Array(true);
+  for (auto it : registry.MaxGauges()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->Get()));
+    max_gauges->add(meter);
+  }
+  obj->set("max_gauges", max_gauges);
+
+  Poco::JSON::Array::Ptr mono_counters = new Poco::JSON::Array(true);
+  for (auto it : registry.MonotonicCounters()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->Delta()));
+    mono_counters->add(meter);
+  }
+  obj->set("mono_counters", mono_counters);
+
+  Poco::JSON::Array::Ptr timers = new Poco::JSON::Array(true);
+  for (auto it : registry.Timers()) {
+    auto meter = fmt_meter_object((spectator::Meter*)it);
+    meter->set("value", fmt::format("{}", it->TotalTime()));
+    timers->add(meter);
+  }
+  obj->set("timers", timers);
+
+  res.setStatus(HTTPResponse::HTTP_OK);
+  res.setContentType("application/json");
+  obj->stringify(res.send());
+}
+
+spectator::Id parse_id(const std::string& id_str) {
+  // get name (tags are specified with , but are optional)
+  auto pos = id_str.find_first_of(',');
+  if (pos == std::string_view::npos) {
+    return Id{id_str, Tags{}};
+  }
+
+  auto name = id_str.substr(0, pos);
+  spectator::Tags tags{};
+
+  // optionally get tags
+  if (id_str[pos] == ',') {
+    while (id_str[pos] != std::string_view::npos) {
+      ++pos;
+      auto k_pos = id_str.find('=', pos);
+      if (k_pos == std::string_view::npos) break;
+      auto key = id_str.substr(pos, k_pos - pos);
+      ++k_pos;
+      auto v_pos = id_str.find_first_of(',', k_pos);
+      std::string val;
+      if (v_pos == std::string_view::npos) {
+        tags.add(key, id_str.substr(k_pos, id_str.length() - k_pos));
+        break;
+      } else {
+        tags.add(key, id_str.substr(k_pos, v_pos - k_pos));
+      }
+      pos = v_pos;
+    }
+  }
+
+  return spectator::Id{name, tags};
+}
+
+void DELETE_metrics(const std::string& type, HTTPServerRequest& req, HTTPServerResponse& res,
+                    std::shared_ptr<spdlog::logger>& logger, spectator::Registry& registry) {
+  if (req.getURI().size() == 10) {
+    logger->info("DELETE /metrics/{} succeeded: all meters deleted", type);
+    registry.DeleteAllMeters(type);
+    res.setStatus(HTTPResponse::HTTP_OK);
+    res.send();
+  } else {
+    auto id = parse_id(req.getURI().substr(11));
+    if (registry.DeleteMeter(type, id)) {
+      logger->info("DELETE /metrics/{} succeeded: '{}'", type, id);
+      res.setStatus(HTTPResponse::HTTP_OK);
+      res.send();
+    } else {
+      logger->error("DELETE /metrics/{} failed: meter not found '{}'", type, id);
+      res.setStatus(HTTPResponse::HTTP_NOT_FOUND);
+      res.setReason("Not Found");
+      res.send();
+    }
+  }
+}
+
+void RequestHandler::handleRequest(HTTPServerRequest& req, HTTPServerResponse& res) {
+  this->logger->debug("AdminServer request for URI={}", req.getURI());
+
+  auto localhost_found =
+      req.getHost().rfind("localhost") != std::string::npos ||
+      req.getHost().rfind("127.0.0.1") != std::string::npos ||
+      req.getHost().rfind("[::1]") != std::string::npos;
+
+  if (req.getURI() == "/" && req.getMethod() == "GET") {
+    // describe admin service
+    GET_root(req, res);
+  } else if (req.getURI() == "/config" && req.getMethod() == "GET") {
+    // get the full spectator configuration
+    GET_config(req, res, this->registry.GetConfig());
+  } else if (req.getURI() == "/config/common_tags" && req.getMethod() == "GET") {
+    // describe common_tags usage
+    GET_config_common_tags(req, res, join(this->allowed_tags, ", "));
+  } else if (req.getURI() == "/config/common_tags" && req.getMethod() == "POST") {
+    // update the common_tags config
+    if (localhost_found) {
+      POST_config_common_tags(req, res, this->logger, this->allowed_tags, this->registry);
+    } else {
+      this->logger->error("AdminServer endpoint may only be accessed from localhost method={} uri={} ", req.getMethod(), req.getURI());
+      res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+      res.setReason("Bad Request");
+      res.send();
+    }
+  } else if (req.getURI() == "/metrics" && req.getMethod() == "GET") {
+    // get all metrics defined in the registry
+    GET_metrics(req, res, this->registry);
+  } else if (req.getURI().rfind("/metrics/A", 0) == 0  && req.getMethod() == "DELETE") {
+    // delete one or all age gauges
+    if (localhost_found) {
+      DELETE_metrics("A", req, res, this->logger, this->registry);
+    } else {
+      this->logger->error("AdminServer endpoint may only be accessed from localhost method={} uri={} ", req.getMethod(), req.getURI());
+      res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+      res.setReason("Bad Request");
+      res.send();
+    }
+  } else if (req.getURI().rfind("/metrics/g", 0) == 0 && req.getMethod() == "DELETE") {
+    // delete one or all gauges
+    if (localhost_found) {
+      DELETE_metrics("g", req, res, this->logger, this->registry);
+    } else {
+      this->logger->error("AdminServer endpoint may only be accessed from localhost method={} uri={} ", req.getMethod(), req.getURI());
+      res.setStatus(HTTPResponse::HTTP_BAD_REQUEST);
+      res.setReason("Bad Request");
+      res.send();
+    }
+  } else {
+    this->logger->error("AdminServer unknown endpoint method={} uri={} ", req.getMethod(), req.getURI());
+    res.setStatus(HTTPResponse::HTTP_NOT_FOUND);
+    res.setReason("Not Found");
+    res.send();
+  }
+}
+
+}

--- a/admin/admin_server.h
+++ b/admin/admin_server.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "spectator/registry.h"
+#include <Poco/Net/HTTPServer.h>
+#include <Poco/Net/HTTPRequestHandler.h>
+
+namespace admin {
+
+std::string join(std::vector<std::string> const& strings, const std::string& delimiter);
+spectator::Id parse_id(const std::string& id_str);
+
+class RequestHandler: public Poco::Net::HTTPRequestHandler {
+  spectator::Registry &registry;
+  std::shared_ptr<spdlog::logger> logger = spectatord::Logger();
+
+  // tags which may be modified by the config/common_tags endpoint
+  std::vector<std::string> allowed_tags {
+      "mantisJobId",
+      "mantisJobName",
+      "mantisUser",
+      "mantisWorkerIndex",
+      "mantisWorkerNumber",
+      "mantisWorkerStageNumber"
+  };
+
+ public:
+  explicit RequestHandler(spectator::Registry &r): registry{r} {}
+  void handleRequest(Poco::Net::HTTPServerRequest &, Poco::Net::HTTPServerResponse &) override;
+};
+
+class RequestHandlerFactory: public Poco::Net::HTTPRequestHandlerFactory {
+  spectator::Registry &registry;
+
+ public:
+  explicit RequestHandlerFactory(spectator::Registry &r): registry{r} {}
+  Poco::Net::HTTPRequestHandler* createRequestHandler(const Poco::Net::HTTPServerRequest &) override {
+    return new admin::RequestHandler(this->registry);
+  }
+};
+
+class AdminServer {
+  std::shared_ptr<Poco::Net::HTTPServer> instance;
+  spectator::Registry &registry;
+
+ public:
+  AdminServer(spectator::Registry &r, int p):
+    registry{r},
+    instance{std::make_shared<Poco::Net::HTTPServer>(new RequestHandlerFactory(r), p)} {}
+  void Start() { instance->start(); }
+  void Stop() { instance->stop(); }
+};
+
+}

--- a/admin/admin_server_test.cc
+++ b/admin/admin_server_test.cc
@@ -1,0 +1,415 @@
+#include "admin_server.h"
+#include "util/logger.h"
+#include "gtest/gtest.h"
+#include "spectator/config.h"
+#include "spectator/registry.h"
+#include <Poco/JSON/Parser.h>
+#include <Poco/Net/HTTPClientSession.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+
+namespace {
+
+using namespace Poco::Dynamic;
+using namespace Poco::JSON;
+using namespace Poco::Net;
+
+using spectator::Id;
+using spectator::Tags;
+
+constexpr const char* const kDefaultHost = "localhost";
+constexpr int kDefaultPort = 8080;
+
+std::unique_ptr<spectator::Config> GetConfiguration() {
+  auto config = std::make_unique<spectator::Config>();
+  config->age_gauge_limit = 10;
+  return config;
+}
+
+bool contains(const std::vector<std::string>& vec, const std::string& key) {
+  if (std::find(vec.begin(), vec.end(), key) != vec.end()) {
+    return true;
+  }
+  return false;
+}
+
+/** Add operator overload function to solve for the following compilation error:
+ *
+ * include/fmt/core.h:2001:35: error: ambiguous overload for ‘operator==’ (operand types are ‘const char* const’ and ‘fmt::v8::basic_string_view<char>’)
+ * include/Poco/Dynamic/Var.h:2008:13: note: candidate: ‘bool Poco::Dynamic::operator==(const bool&, const Poco::Dynamic::Var&)’
+ * include/Poco/Dynamic/Var.h:2024:13: note: candidate: ‘bool Poco::Dynamic::operator==(const string&, const Poco::Dynamic::Var&)’
+ * include/Poco/Dynamic/Var.h:2056:13: note: candidate: ‘bool Poco::Dynamic::operator==(const char*, const Poco::Dynamic::Var&)’
+ */
+inline bool operator == (const char* a, fmt::basic_string_view<char> b) {
+  if (strlen(a) != b.size()) {
+    return false;
+  }
+
+  std::string::size_type i = 0;
+  for (auto p{ a }; *p; ++p) {
+    if (*p != b[i]) {
+      return false;
+    }
+    i++;
+  }
+
+  return true;
+}
+
+class AdminServerTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (server == nullptr) {
+      auto logger = spectatord::Logger();
+      logger->info("Start test instance of AdminServer on {}/tcp", kDefaultPort);
+      registry = new spectator::Registry(GetConfiguration(), logger);
+      registry->GetAgeGauge("ag1");
+      registry->GetAgeGauge("ag2", Tags{{"some.tag", "one"}});
+      registry->GetAgeGauge("ag3", Tags{{"some.tag", "one"}, {"other.tag", "two"}});
+      server = new admin::AdminServer(*registry, kDefaultPort);
+      server->Start();
+    }
+  }
+
+  static void TearDownTestSuite() {
+    auto logger = spectatord::Logger();
+    logger->info("Shutdown test instance of AdminServer");
+
+    server->Stop();
+    delete server;
+    server = nullptr;
+
+    registry->Stop();
+    delete registry;
+    registry = nullptr;
+  }
+
+  static spectator::Registry *registry;
+  static admin::AdminServer *server;
+};
+
+spectator::Registry* AdminServerTest::registry = nullptr;
+admin::AdminServer* AdminServerTest::server = nullptr;
+
+TEST_F(AdminServerTest, EqualsOperator) {
+  EXPECT_TRUE((const char*) "foobar" == (fmt::basic_string_view<char>) "foobar");
+  EXPECT_FALSE((const char*) "foobar" == (fmt::basic_string_view<char>) "foo");
+  EXPECT_FALSE((const char*) "foobar" == (fmt::basic_string_view<char>) "foobaz");
+}
+
+TEST_F(AdminServerTest, Join) {
+  std::vector<std::string> strings {"a", "b", "c"};
+  EXPECT_EQ(admin::join(strings, ","), "a,b,c");
+}
+
+TEST_F(AdminServerTest, Parse_Id) {
+  spectator::Id id = Id{"g", {}};
+  spectator::Id parsed_id = admin::parse_id("g");
+  EXPECT_EQ(parsed_id, id);
+
+  id = Id{"g", Tags{{"some.tag", "one"}}};
+  parsed_id = admin::parse_id("g,some.tag=one");
+  EXPECT_EQ(parsed_id, id);
+
+  id = Id{"g", Tags{{"some.tag", "one"}, {"other.tag", "two"}}};
+  parsed_id = admin::parse_id("g,some.tag=one,other.tag=two");
+  EXPECT_EQ(parsed_id, id);
+
+  id = Id{"g", Tags{{"some.tag", "one"}, {"other.tag", "two_10"}}};
+  parsed_id = admin::parse_id("g,some.tag=one,other.tag=two:10");
+  EXPECT_EQ(parsed_id, id);
+}
+
+TEST_F(AdminServerTest, GET_root) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/");
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+
+  EXPECT_EQ(res.getStatus(), 200);
+  EXPECT_EQ(res.getContentType(), "application/json");
+
+  Parser parser;
+  Var result {parser.parse(rr)};
+  Object::Ptr object = result.extract<Object::Ptr>();
+
+  int count = 0;
+  std::vector<std::string> expected_keys {"description", "endpoints"};
+  for (auto &it : *object) {
+    if (contains(expected_keys, it.first)) {
+      count += 1;
+    }
+  }
+
+  EXPECT_EQ(count, expected_keys.size());
+}
+
+TEST_F(AdminServerTest, GET_config) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/config");
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+
+  EXPECT_EQ(res.getStatus(), 200);
+  EXPECT_EQ(res.getContentType(), "application/json");
+
+  Parser parser;
+  Var result {parser.parse(rr)};
+  Object::Ptr object = result.extract<Object::Ptr>();
+
+  int count = 0;
+  std::vector<std::string> expected_keys {"age_gauge_limit", "batch_size", "common_tags",
+                                         "connect_timeout", "expiration_frequency", "frequency",
+                                         "meter_ttl", "read_timeout", "uri"};
+  for (auto &it : *object) {
+    if (contains(expected_keys, it.first)) {
+      count += 1;
+    }
+  }
+
+  EXPECT_EQ(count, expected_keys.size());
+}
+
+TEST_F(AdminServerTest, GET_config_common_tags) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/config/common_tags");
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+  std::string content(std::istreambuf_iterator<char>(rr), { });
+
+  EXPECT_EQ(res.getStatus(), 200);
+  EXPECT_EQ(res.getContentType(), "application/json");
+  EXPECT_EQ(content.size(), 420);
+}
+
+TEST_F(AdminServerTest, GET_metrics) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/metrics");
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+
+  EXPECT_EQ(res.getStatus(), 200);
+  EXPECT_EQ(res.getContentType(), "application/json");
+
+  Parser parser;
+  Var result {parser.parse(rr)};
+  Object::Ptr object = result.extract<Object::Ptr>();
+
+  int count = 0;
+  std::vector<std::string> expected_keys {"age_gauges", "counters", "dist_summaries",
+                                         "gauges", "max_gauges", "mono_counters", "timers"};
+  for (auto &it : *object) {
+    if (contains(expected_keys, it.first)) {
+      count += 1;
+    }
+  }
+
+  EXPECT_EQ(count, expected_keys.size());
+}
+
+TEST_F(AdminServerTest, GET_undefined_route) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/foo");
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  s.receiveResponse(res);
+
+  EXPECT_EQ(res.getStatus(), 404);
+  EXPECT_EQ(res.getReason(), "Not Found");
+  EXPECT_EQ(res.getContentType(), "");
+}
+
+HTTPResponse post(const std::string& uri, const std::string& body) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_POST, uri);
+  s.sendRequest(req) << body;
+  HTTPResponse res;
+  s.receiveResponse(res);
+  return res;
+}
+
+void expect_bad_request(const HTTPResponse& res) {
+  EXPECT_EQ(res.getStatus(), 400);
+  EXPECT_EQ(res.getReason(), "Bad Request");
+  EXPECT_EQ(res.getContentType(), "application/json");
+}
+
+TEST_F(AdminServerTest, common_tags_Invalid_JSON) {
+  HTTPResponse res = post("/config/common_tags", "{");
+  expect_bad_request(res);
+
+  res = post("/config/common_tags", "[");
+  expect_bad_request(res);
+
+  res = post("/config/common_tags", R"(["nf.app": "foo", "nf.wat": "bar"])");
+  expect_bad_request(res);
+}
+
+TEST_F(AdminServerTest, common_tags_Array_Not_Allowed) {
+  // an object is expected
+  HTTPResponse res = post("/config/common_tags", R"(["foo", "bar", "baz"])");
+  expect_bad_request(res);
+}
+
+TEST_F(AdminServerTest, common_tags_Disallowed_Keys) {
+  // all keys invalid
+  HTTPResponse res = post("/config/common_tags", R"({"nf.app": "foo", "nf.stack": "bar"})");
+  expect_bad_request(res);
+
+  // some keys invalid
+  res = post("/config/common_tags", R"({"nf.app": "foo", "mantisJobId": "bar"})");
+  expect_bad_request(res);
+
+  res = post("/config/common_tags", R"({"mantisJobId": "foo", "nf.app": "yolo", "mantisJobName": "bar", "mantisUser": ""})");
+  expect_bad_request(res);
+}
+
+TEST_F(AdminServerTest, common_tags_Allowed_Keys_Invalid_Values) {
+  HTTPResponse res = post("/config/common_tags", R"({"mantisJobId": "foo", "mantisJobName": "bar", "mantisUser": 1})");
+  expect_bad_request(res);
+}
+
+Object::Ptr get_common_tags() {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/config");
+  s.sendRequest(req);
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+
+  Parser parser;
+  Var result {parser.parse(rr)};
+  Object::Ptr object = result.extract<Object::Ptr>();
+  Var common_tags = object->get("common_tags");
+  return common_tags.extract<Object::Ptr>();
+}
+
+TEST_F(AdminServerTest, set_common_tags) {
+  // start with zero common tags
+  Object::Ptr subObject = get_common_tags();
+
+  int count = 0;
+  for (auto &it : *subObject) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 0);
+
+  // set three common tags
+  post("/config/common_tags", R"({"mantisJobId": "foo", "mantisJobName": "bar", "mantisUser": "baz"})");
+  subObject = get_common_tags();
+
+  count = 0;
+  for (auto &it : *subObject) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 3);
+  EXPECT_EQ("foo", subObject->get("mantisJobId"));
+  EXPECT_EQ("bar", subObject->get("mantisJobName"));
+  EXPECT_EQ("baz", subObject->get("mantisUser"));
+
+  // change one tag, delete one tag
+  post("/config/common_tags", R"({"mantisJobName": "quux", "mantisUser": ""})");
+  subObject = get_common_tags();
+
+  count = 0;
+  for (auto &it : *subObject) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 2);
+  EXPECT_EQ("foo", subObject->get("mantisJobId"));
+  EXPECT_EQ("quux", subObject->get("mantisJobName"));
+
+  // reset all tags
+  post("/config/common_tags", R"({"mantisJobId": "", "mantisJobName": ""})");
+  subObject = get_common_tags();
+
+  count = 0;
+  for (auto &it : *subObject) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 0);
+}
+
+Poco::JSON::Array::Ptr get_metrics(const std::string& type) {
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_GET, "/metrics");
+  s.sendRequest(req);
+  HTTPResponse res;
+  std::istream& rr = s.receiveResponse(res);
+
+  Parser parser;
+  Var result {parser.parse(rr)};
+  Object::Ptr object = result.extract<Object::Ptr>();
+  Var metrics;
+  if (type == "A") {
+    metrics = object->get("age_gauges");
+  } else if (type == "g") {
+    metrics = object->get("gauges");
+  }
+
+  return metrics.extract<Poco::JSON::Array::Ptr>();
+}
+
+HTTPResponse delete_age_gauge(const std::string& id) {
+  std::string uri;
+  if (id.empty()) {
+    uri = "/metrics/A";
+  } else {
+    uri = "/metrics/A/" + id;
+  }
+
+  HTTPClientSession s(kDefaultHost, kDefaultPort);
+  HTTPRequest req(HTTPRequest::HTTP_DELETE, uri);
+  s.sendRequest(req);
+
+  HTTPResponse res;
+  s.receiveResponse(res);
+
+  return res;
+}
+
+TEST_F(AdminServerTest, delete_meters) {
+  // start with three pre-populated age gauges
+  Poco::JSON::Array::Ptr subArr = get_metrics("A");
+  int count = 0;
+  for (auto &it : *subArr) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 3);
+
+  HTTPResponse res;
+
+  res = delete_age_gauge("ag1");
+  EXPECT_EQ(200, res.getStatus());
+
+  res = delete_age_gauge("ag1");
+  EXPECT_EQ(404, res.getStatus());
+
+  res = delete_age_gauge("ag3,some.tag=one,other.tag=two");
+  EXPECT_EQ(200, res.getStatus());
+
+  // bad id formats will get mangled into the last tag, and thus not match
+  res = delete_age_gauge("ag1,foo=bar:10");
+  EXPECT_EQ(404, res.getStatus());
+
+  // delete all remaining age gauges
+  res = delete_age_gauge("");
+  EXPECT_EQ(200, res.getStatus());
+
+  subArr = get_metrics("A");
+  count = 0;
+  for (auto &it : *subArr) {
+    count += 1;
+  }
+  EXPECT_EQ(count, 0);
+}
+
+}

--- a/build.sh
+++ b/build.sh
@@ -28,14 +28,22 @@ if [[ ! -d $BUILD_DIR ]]; then
   conan install . --build=missing --install-folder $BUILD_DIR
 
   echo -e "${BLUE}==== install source dependencies ====${NC}"
-  conan source .
+  if [[ "$NFLX_INTERNAL" == "ON" ]]; then
+    NFLX_INTERNAL=ON conan source .
+  else
+    conan source .
+  fi
 fi
 
 pushd $BUILD_DIR || exit 1
 
 echo -e "${BLUE}==== generate build files ====${NC}"
 # Choose: Debug, Release, RelWithDebInfo and MinSizeRel
-cmake .. -DCMAKE_BUILD_TYPE=Debug || exit 1
+if [[ "$NFLX_INTERNAL" == "ON" ]]; then
+  cmake .. -DCMAKE_BUILD_TYPE=Debug -DNFLX_INTERNAL=ON || exit 1
+else
+  cmake .. -DCMAKE_BUILD_TYPE=Debug -DNFLX_INTERNAL=OFF || exit 1
+fi
 
 echo -e "${BLUE}==== build ====${NC}"
 cmake --build . || exit 1

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,15 +15,26 @@ class SpectatorDConan(ConanFile):
         "c-ares/1.15.0",
         "fmt/7.1.3",
         "gtest/1.10.0",
-        "libcurl/7.74.0",
+        "libcurl/7.87.0",
+        "openssl/1.1.1t",
+        "poco/1.12.4",
         "rapidjson/1.1.0",
-        "spdlog/1.8.0",
+        "spdlog/1.8.5",
         "tsl-hopscotch-map/2.3.0",
         "xxhash/0.8.0",
-        "zlib/1.2.11"
+        "zlib/1.2.13"
     )
     generators = "cmake"
     default_options = {}
+
+    def configure(self):
+        self.options["poco"].enable_data_mysql = False
+        self.options["poco"].enable_data_postgresql = False
+        self.options["poco"].enable_data_sqlite = False
+        self.options["poco"].enable_jwt = False
+        self.options["poco"].enable_mongodb = False
+        self.options["poco"].enable_redis = False
+        self.options["poco"].enable_activerecord = False
 
     @staticmethod
     def get_flat_hash_map():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-conan
+conan==1.59.0

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -330,7 +330,7 @@ void Server::Start() {
   logger->info("Using receive buffer size = {}", max_buffer_size());
   auto parser = [this](char* buffer) { return this->parse(buffer); };
   UdpServer udp_server{io_context, port_number_, parser};
-  logger->info("Starting spectatord server on port {}", port_number_);
+  logger->info("Starting spectatord server on port {}/udp", port_number_);
   udp_server.Start();
 
   std::unique_ptr<UdpServer> statsd_server;
@@ -340,7 +340,7 @@ void Server::Start() {
     };
     statsd_server = std::make_unique<UdpServer>(io_context, *statsd_port_number_,
                                                 statsd_parser);
-    logger->info("Starting statsd server on port {}", *statsd_port_number_);
+    logger->info("Starting statsd server on port {}/udp", *statsd_port_number_);
     statsd_server->Start();
   } else {
     logger->info("statsd support is not enabled");

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -155,6 +155,36 @@ auto Registry::Measurements() const noexcept -> std::vector<Measurement> {
   return res;
 }
 
+void Registry::UpdateCommonTag(const std::string& k, const std::string& v) {
+  auto it = config_->common_tags.find(k);
+  if (it != config_->common_tags.end()) {
+    it->second = v;
+  } else {
+    config_->common_tags.insert({k, v});
+  }
+}
+
+void Registry::EraseCommonTag(const std::string& k) {
+  config_->common_tags.erase(k);
+}
+
+bool Registry::DeleteMeter(const std::string& type, const Id& id) {
+  if (type == "A") {
+    return all_meters_.age_gauges_.remove_one(id);
+  } else if (type == "g") {
+    return all_meters_.gauges_.remove_one(id);
+  }
+  return false;
+}
+
+void Registry::DeleteAllMeters(const std::string& type) {
+  if (type == "A") {
+    all_meters_.age_gauges_.remove_all();
+  } else if (type == "g") {
+    all_meters_.gauges_.remove_all();
+  }
+}
+
 void Registry::remove_expired_meters() noexcept {
   int total = 0, expired = 0;
   std::tie(expired, total) = all_meters_.remove_expired(meter_ttl_);

--- a/spectator/sample_config.cc
+++ b/spectator/sample_config.cc
@@ -4,7 +4,9 @@ namespace spectator {
 
 // used in tests
 auto GetConfiguration() -> std::unique_ptr<Config> {
-  return std::make_unique<Config>();
+  auto config = std::make_unique<Config>();
+  config->age_gauge_limit = 10;
+  return config;
 }
 
 }  // namespace spectator

--- a/spectator/string_intern_test.cc
+++ b/spectator/string_intern_test.cc
@@ -32,7 +32,7 @@ TEST(StringIntern, Valid) {
   EXPECT_EQ(intern_str(very_invalid), intern_str("12_45"));
 }
 
-TEST(StringInter, Hash) {
+TEST(StringIntern, Hash) {
   auto h1 = std::hash<spectator::StrRef>{}(intern_str("hash"));
   auto h2 = std::hash<spectator::StrRef>{}(intern_str("hash1"));
   auto h3 = std::hash<spectator::StrRef>{}(intern_str("hash2"));

--- a/tools/admin-server-cli-test.sh
+++ b/tools/admin-server-cli-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# -- api /: help --
+echo "-- / help"
+curl -s http://localhost:1234 | jq .
+
+# -- api /config/common_tags: help --
+echo "-- /config/common_tags help"
+curl -s http://localhost:1234/config/common_tags | jq .
+
+# -- api /config: spectator config --
+echo "-- /config spectator config"
+curl -s http://localhost:1234/config | jq .
+
+# -- api /config/common_tags: error handling validation --
+echo "-- invalid json - expect 400"
+curl -X POST -d '{' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -X POST -d '[' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -X POST -d '["nf.app": "foo", "nf.wat": "bar"]' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+echo "-- array not allowed - expect 400"
+curl -X POST -d '["foo", "bar", "baz"]' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+echo "-- all invalid keys - expect 400"
+curl -X POST -d '{"nf.app": "foo", "nf.stack": "bar"}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+echo "-- some invalid keys - expect 400"
+curl -X POST -d '{"nf.app": "foo", "mantisJobId": "bar"}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -X POST -d '{"mantisJobId": "foo", "nf.app": "yolo", "mantisJobName": "bar", "mantisUser": ""}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+echo "-- all valid keys (mantisJobId=foo mantisJobName=bar mantisUser='') - expect 200"
+curl -X POST -d '{"mantisJobId": "foo", "mantisJobName": "bar", "mantisUser": ""}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+echo "-- valid keys, invalid values - expect 400"
+curl -X POST -d '{"mantisJobId": "foo", "mantisJobName": "bar", "mantisUser": 1}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+
+# -- api /config/common_tags: update validation --
+echo "-- starting common tags"
+curl -s http://localhost:1234/config |jq '.common_tags'
+
+echo "-- set common tags"
+curl -X POST -d '{"mantisJobId": "foo", "mantisJobName": "bar", "mantisUser": "baz"}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -s http://localhost:1234/config |jq '.common_tags'
+
+echo "-- overwrite common tags"
+curl -X POST -d '{"mantisJobId": "new-foo", "mantisJobName": "new-bar", "mantisUser": "new-baz"}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -s http://localhost:1234/config |jq '.common_tags'
+
+echo "-- delete common tags"
+curl -X POST -d '{"mantisJobId": ""}' -w " %{http_code}\n" http://localhost:1234/config/common_tags
+curl -s http://localhost:1234/config |jq '.common_tags'
+
+# -- api: /metrics output validation --
+echo "-- list all registry metrics"
+curl -s http://localhost:1234/metrics | jq .


### PR DESCRIPTION
This change adds an administrative server to SpectatorD, for the purpose of providing debugging information and making small changes to the running configuration.

The Mantis application needed the ability to change their common tags on the fly during operation, as they swap out jobs and the `/config/common_tags` endpoint provides this feature.

Users of AgeGauges occasionally need the ability to delete the AgeGauges they create - the `/metrics/A` endpoint provides this feature.