### PR TITLE
re-enable ultimate stack traces for backward-cpp on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ include(CTest)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+if (UNIX AND NOT APPLE)
+    message(STATUS "platform is linux")
+    set(BACKWARD_LIBS "-lbfd -ldl")
+else()
+    message(STATUS "platform is NOT linux")
+    set(BACKWARD_LIBS "")
+endif()
+
 add_subdirectory(admin)
 add_subdirectory(bench)
 add_subdirectory(server)
@@ -32,6 +40,7 @@ target_link_libraries(spectator_test
     sample_cfg
     spectator
     util
+    ${BACKWARD_LIBS}
     ${CONAN_LIBS}
 )
 add_test(
@@ -50,7 +59,12 @@ add_executable(spectatord_test
     "spectator/test_utils.h"
 )
 target_include_directories(spectatord_test PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(spectatord_test admin_server spectatord ${CONAN_LIBS})
+target_link_libraries(spectatord_test
+    admin_server
+    spectatord
+    ${BACKWARD_LIBS}
+    ${CONAN_LIBS}
+)
 add_test(
     NAME spectatord_test
     COMMAND spectatord_test
@@ -70,6 +84,7 @@ if(NFLX_INTERNAL)
         netflix_cfg
         spectatord
         admin_server
+        ${BACKWARD_LIBS}
         ${CONAN_LIBS}
     )
 else()
@@ -78,6 +93,7 @@ else()
         sample_cfg
         spectatord
         admin_server
+        ${BACKWARD_LIBS}
         ${CONAN_LIBS}
     )
 endif()

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define BACKWARD_HAS_BFD 1
+#endif
 #include "backward.hpp"
 #include "util/logger.h"
 #include "spectatord.h"

--- a/bin/test_main.cc
+++ b/bin/test_main.cc
@@ -1,3 +1,6 @@
+#ifdef __linux__
+#define BACKWARD_HAS_BFD 1
+#endif
 #include "backward.hpp"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
During the transition to Conan and CMake, we lost the configuration necessary for ultimate stack traces to be recorded on Linux platforms. This only works on Linux, so we need to conditionally link the extra libraries.