### PR TITLE
revert libbfd linking for backward-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,6 @@ include(CTest)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-if (UNIX AND NOT APPLE)
-    message(STATUS "platform is linux")
-    set(BACKWARD_LIBS "-lbfd -ldl")
-else()
-    message(STATUS "platform is NOT linux")
-    set(BACKWARD_LIBS "")
-endif()
-
 add_subdirectory(admin)
 add_subdirectory(bench)
 add_subdirectory(server)
@@ -40,7 +32,6 @@ target_link_libraries(spectator_test
     sample_cfg
     spectator
     util
-    ${BACKWARD_LIBS}
     ${CONAN_LIBS}
 )
 add_test(
@@ -62,7 +53,6 @@ target_include_directories(spectatord_test PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(spectatord_test
     admin_server
     spectatord
-    ${BACKWARD_LIBS}
     ${CONAN_LIBS}
 )
 add_test(
@@ -84,7 +74,6 @@ if(NFLX_INTERNAL)
         netflix_cfg
         spectatord
         admin_server
-        ${BACKWARD_LIBS}
         ${CONAN_LIBS}
     )
 else()
@@ -93,7 +82,6 @@ else()
         sample_cfg
         spectatord
         admin_server
-        ${BACKWARD_LIBS}
         ${CONAN_LIBS}
     )
 endif()

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -1,6 +1,3 @@
-#ifdef __linux__
-#define BACKWARD_HAS_BFD 1
-#endif
 #include "backward.hpp"
 #include "util/logger.h"
 #include "spectatord.h"

--- a/bin/test_main.cc
+++ b/bin/test_main.cc
@@ -1,6 +1,3 @@
-#ifdef __linux__
-#define BACKWARD_HAS_BFD 1
-#endif
 #include "backward.hpp"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Linking against this library introduces strong distro-specific requirements which complicates the build and distribution process. We want to keep things simple and as generic as possible, so we will abandon getting ultimate stack traces on the Linux platform.

To help deal with segmentation faults, we will press forward with migrating to systemd startup scripts, so that we can control the behavior of core dumps.