### PR TITLE
reduce spectatord logging

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -405,8 +405,8 @@ class Publisher {
     }
 
     auto elapsed = absl::Now() - start;
-    logger->info("Sent: {} Dropped: {} Total: {}. Elapsed {:.3f}s", num_sent,
-                 num_err, measurements.size(), absl::ToDoubleSeconds(elapsed));
+    logger->debug("Sent: {} Dropped: {} Total: {}. Elapsed {:.3f}s", num_sent,
+                  num_err, measurements.size(), absl::ToDoubleSeconds(elapsed));
     for (const auto& m : err_messages) {
       logger->info("Validation error: {}", m);
     }


### PR DESCRIPTION
The `Sent:` messages serve as a positive confirmation that spectatord is either delivering or dropping measurements, but there is generally no action to be taken from it directly, and this information is also recorded in the `spectator.measurements` metric.

In the case of Titus, this message alone is responsible for 25% of all logs.

Moving this message to the `debug` level drops it from the standard use case, while still allowing it to be accessed if the `--verbose` flag is passed to the binary.

Fixes #71.