### PR TITLE
add owner tag to generic spectator metrics

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -27,6 +27,7 @@ namespace detail {
 template <typename R>
 auto get_counter(R* registry, Tags tags) -> std::shared_ptr<Counter> {
   static constexpr auto kSpectatorMeasurements = "spectator.measurements";
+  tags.add("owner", "spectatord");
   return registry->GetCounter(kSpectatorMeasurements, std::move(tags));
 }
 }  // namespace detail

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -13,7 +13,7 @@ Registry::Registry(std::unique_ptr<Config> config,
       meter_ttl_{absl::ToInt64Nanoseconds(config->meter_ttl)},
       config_{std::move(config)},
       logger_{std::move(logger)},
-      registry_size_{GetDistributionSummary("spectator.registrySize")},
+      registry_size_{GetDistributionSummary("spectator.registrySize", Tags{{"owner", "spectatord"}})},
       publisher_(this) {
   if (meter_ttl_ == 0) {
     meter_ttl_ = int64_t(15) * 60 * 1000 * 1000 * 1000;

--- a/spectator/registry_test.cc
+++ b/spectator/registry_test.cc
@@ -184,7 +184,7 @@ TEST(Registry, DistSummary_Size) {
   r.GetCounter("bar")->Increment();
   // we have 4 measurements from the timer + 1 from the counter
   r.Measurements();
-  EXPECT_DOUBLE_EQ(r.GetDistributionSummary("spectator.registrySize")->TotalAmount(), 5.0);
+  EXPECT_DOUBLE_EQ(r.GetDistributionSummary("spectator.registrySize", Tags{{"owner", "spectatord"}})->TotalAmount(), 5.0);
 }
 
 TEST(Registry, DeleteMeters) {


### PR DESCRIPTION
This allows these metrics to be tracked back to spectatord, as needed, and it
mirrors the tagging convention for ipc metrics.