### PR TITLE
enable connection reuse in libcurl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           tools/generate_version.sh > spectator/version.h
           cd $BUILD_DIR
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_BUILD_TYPE=Debug
           cmake --build .
           echo "==== ldd ===="
           ldd bin/spectatord_main || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,3 +100,8 @@ target_include_directories(metrics_gen PRIVATE
 )
 target_link_libraries(metrics_gen ${CONAN_LIBS})
 target_link_options(metrics_gen PRIVATE -pthread)
+
+#-- multi_test
+add_executable(multi_test "bin/multi_test.cc")
+target_include_directories(multi_test PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(multi_test ${CONAN_LIBS})

--- a/bin/multi_test.cc
+++ b/bin/multi_test.cc
@@ -1,0 +1,86 @@
+#include <string>
+#include <vector>
+#include <curl/curl.h>
+
+#define HANDLECOUNT 10
+
+struct Errbuf {
+  char msg[CURL_ERROR_SIZE];
+};
+
+size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+  ((std::string*)userp)->append((char*)contents, size * nmemb);
+  return size * nmemb;
+}
+
+int main(void) {
+  CURLM *multi_handle;
+  std::vector<CURL*> handles;
+  std::vector<std::string> readBuffers;
+  std::vector<Errbuf> errbufs;
+
+  for (int i = 0; i<HANDLECOUNT; i++) {
+    handles.emplace_back(curl_easy_init());
+    readBuffers.emplace_back(std::string());
+    errbufs.emplace_back(Errbuf());
+
+    curl_easy_setopt(handles[i], CURLOPT_URL, "https://example.com");
+    curl_easy_setopt(handles[i], CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(handles[i], CURLOPT_WRITEDATA, &readBuffers[i]);
+    curl_easy_setopt(handles[i], CURLOPT_ERRORBUFFER, errbufs[i].msg);
+  }
+
+  printf("handles.size=%zu readBuffers.size=%zu errbufs.size=%zu\n",
+         handles.size(), readBuffers.size(), errbufs.size());
+
+  multi_handle = curl_multi_init();
+
+  for (int i = 0; i<HANDLECOUNT; i++)
+    curl_multi_add_handle(multi_handle, handles[i]);
+
+  CURLMsg *msg;
+  int msgs_left;
+  int still_running = 1;
+
+  while (still_running) {
+    CURLMcode mc = curl_multi_perform(multi_handle, &still_running);
+    printf("== %d still running ==\n", still_running);
+
+    if (still_running)
+      /* wait for activity, timeout or "nothing" */
+      mc = curl_multi_poll(multi_handle, NULL, 0, 1000, NULL);
+
+    if (mc) {
+      printf("== mc break: %d ==\n", mc);
+      break;
+    }
+  }
+
+  while ((msg = curl_multi_info_read(multi_handle, &msgs_left))) {
+    if (msg->msg == CURLMSG_DONE) {
+      for (int i = 0; i < HANDLECOUNT; i++) {
+        int found = (msg->easy_handle == handles[i]);
+        if (found) {
+          if (msg->data.result == CURLE_OK) {
+            printf("Message from handle %d: transfer ok, size=%zu\n", i, readBuffers[i].size());
+            printf("errbuf=%s\n", errbufs[i].msg);
+            printf("%s", readBuffers[i].c_str());
+          } else {
+            printf("Message from handle %d: not ok %d\n", i, msg->data.result);
+            printf("errbuf=%s\n", errbufs[i].msg);
+          }
+        }
+      }
+    }
+  }
+
+  printf("== remove the transfers and cleanup the handles ==\n");
+  for (int i = 0; i<HANDLECOUNT; i++) {
+    curl_multi_remove_handle(multi_handle, handles[i]);
+    curl_easy_cleanup(handles[i]);
+  }
+
+  curl_multi_cleanup(multi_handle);
+
+  return 0;
+}

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,13 @@ cmake --build . || exit 1
 
 if [[ "$1" != "skiptest" ]]; then
   echo -e "${BLUE}==== test ====${NC}"
-  GTEST_COLOR=1 ASAN_OPTIONS=detect_container_overflow=0 ctest --verbose
+
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    export ASAN_OPTIONS="detect_container_overflow=0"
+    echo "== export ASAN_OPTIONS=$ASAN_OPTIONS"
+  fi
+
+  GTEST_COLOR=1 ctest --verbose
 fi
 
 popd || exit 1

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -78,7 +78,12 @@ class CurlHandle {
 
   auto handle() const noexcept -> CURL* { return handle_; }
 
-  auto perform() -> CURLcode { return curl_easy_perform(handle()); }
+  auto perform() -> CURLcode {
+    if (response_.size() > 0) {
+      response_.clear();
+    }
+    return curl_easy_perform(handle());
+  }
 
   auto set_opt(CURLoption option, const void* param) -> CURLcode {
     return curl_easy_setopt(handle(), option, param);
@@ -199,7 +204,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
                          int attempt_number) const -> HttpResponse {
   LogEntry entry{registry_, method, url};
 
-  CurlHandle curl;
+  thread_local CurlHandle curl;
   auto total_timeout = config_.connect_timeout + config_.read_timeout;
   curl.set_timeout(total_timeout);
   curl.set_connect_timeout(config_.connect_timeout);


### PR DESCRIPTION
Originally, in the `HttpClient::perform()` method, a new `CurlHandle` was created
upon every invocation, leading to subsequent calls to `curl_easy_init()` and
`curl_easy_cleanup()`, as the variable went in and out of scope while it executed
on the `asio::thread_pool`. This meant that there was no opportunity to reuse
connections from the underlying connection pool, because it was always cleaned up.

By marking the `CurlHandle` with the `thread_local` storage duration, it ensures
that the same one remains in use for each thread, thus providing the means to
reuse the established connection pool.

Fixes #51.