### PR TITLE
update build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/*.inc
 .DS_Store
 .idea/
-cmake-build-debug/
+cmake-build-debug
 cmake-build/
 ska/
 spectator/netflix_config.cc

--- a/README.md
+++ b/README.md
@@ -233,11 +233,15 @@ with different kernel settings for UDP sockets.
 ## Local Development
 
 ```shell
+# setup python venv and activate, to gain access to conan cli
 ./setup-venv.sh
 source venv/bin/activate
-./build.sh  # [clean|skiptest]
+
+# link clion default build directory to our build directory
+ln -s cmake-build cmake-build-debug
+
+./build.sh  # [clean|clean --force|skiptest]
 ```
 
 * CLion > Preferences > Plugins > Marketplace > Conan > Install
 * CLion > Preferences > Build, Execution, Deploy > Conan > Conan Executable: $PROJECT_HOME/venv/bin/conan
-* CLion > Bottom Bar: Conan > Left Button: Match Profile > CMake Profile: Debug, Conan Profile: default

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# usage: ./build.sh [clean|clean --force|skiptest]
+
 BUILD_DIR=cmake-build
 # Choose: Debug, Release, RelWithDebInfo and MinSizeRel
 BUILD_TYPE=Debug
@@ -14,8 +16,10 @@ if [[ "$1" == "clean" ]]; then
   rm -rf ska
   rm -f spectator/*.inc
   rm -f spectator/netflix_config.cc
-  # remove all packages and binaries from the local cache, to allow swapping between Debug/Release builds
-  conan remove '*' --force
+  if [[ "$2" == "--force" ]]; then
+    # remove all packages and binaries from the local cache, to allow swapping between Debug/Release builds
+    conan remove '*' --force
+  fi
 fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
The clean function of the build script was removing the conan binary cache far too often, resulting in slower builds. This should be a special action that is only done when switching between Debug and Release builds, where there is an impact on the use of the address sanitizer.