### PR TITLE
always log publisher status when num_err > 0

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -406,8 +406,13 @@ class Publisher {
     }
 
     auto elapsed = absl::Now() - start;
-    logger->debug("Sent: {} Dropped: {} Total: {}. Elapsed {:.3f}s", num_sent,
-                  num_err, measurements.size(), absl::ToDoubleSeconds(elapsed));
+    if (num_err > 0) {
+      logger->info("Sent: {} Dropped: {} Total: {}. Elapsed {:.3f}s", num_sent,
+                    num_err, measurements.size(), absl::ToDoubleSeconds(elapsed));
+    } else {
+      logger->debug("Sent: {} Dropped: {} Total: {}. Elapsed {:.3f}s", num_sent,
+                    num_err, measurements.size(), absl::ToDoubleSeconds(elapsed));
+    }
     for (const auto& m : err_messages) {
       logger->info("Validation error: {}", m);
     }


### PR DESCRIPTION
The logging was reduced for the common standard operating case, but it should also consider the case when there are errors.