### PR TITLE
add --no_common_tags flag

### DIFF
--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -72,6 +72,11 @@ ABSL_FLAG(std::string, common_tags, "",
           "Common tags: nf.app=app,nf.cluster=cluster. Override the default common "
           "tags. If empty, then spectatord will use the default set. "
           "This flag should only be used by experts who understand the risks.");
+ABSL_FLAG(bool, no_common_tags, false,
+          "No common tags will be provided for metrics. Since no common tags are available, no "
+          "internal status metrics will be recorded. Only use this feature for special cases "
+          "where it is absolutely necessary to override common tags such as nf.app, and only "
+          "use it with a secondary spectatord process.");
 ABSL_FLAG(bool, verbose, false,
           "Use verbose logging.");
 ABSL_FLAG(bool, verbose_http, false,
@@ -134,6 +139,11 @@ auto main(int argc, char** argv) -> int {
     cfg->common_tags = std::move(common_tags);
   }
 
+  if (absl::GetFlag(FLAGS_no_common_tags)) {
+    cfg->common_tags.clear();
+    cfg->status_metrics_enabled = false;
+  }
+
   if (!sh.loaded()) {
     logger->info("Unable to load signal handling for stacktraces");
   }
@@ -143,7 +153,7 @@ auto main(int argc, char** argv) -> int {
 
   std::optional<std::string> socket_path;
   if (absl::GetFlag(FLAGS_enable_socket)) {
-      socket_path = absl::GetFlag(FLAGS_socket_path);
+    socket_path = absl::GetFlag(FLAGS_socket_path);
   }
 
   std::optional<int> statsd_port;

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -38,6 +38,7 @@ class Config {
   size_t age_gauge_limit{};
   std::string uri;
   bool verbose_http = false;
+  bool status_metrics_enabled = true;
 
   // sub-classes can override this method implementing custom logic
   // that can disable publishing under certain conditions

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -250,7 +250,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
         absl::ToInt64Milliseconds(total_timeout - config_.connect_timeout));
     if (elapsed < total_timeout && attempt_number < 2) {
       entry.set_attempt(attempt_number, false);
-      entry.log();
+      entry.log(config_.status_metrics_enabled);
       return perform(method, url, std::move(headers), payload, size,
                      attempt_number + 1);
     }
@@ -269,7 +269,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
       logger->info("Got a retryable http code from {}: {} (attempt {})", url,
                    http_code, attempt_number);
       entry.set_attempt(attempt_number, false);
-      entry.log();
+      entry.log(config_.status_metrics_enabled);
       auto sleep_ms = uint32_t(200) << attempt_number;  // 200, 400ms
       std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
       return perform(method, url, std::move(headers), payload, size,
@@ -278,7 +278,7 @@ auto HttpClient::perform(const char* method, const std::string& url,
     logger->debug("{} {} - status code: {}", method, url, http_code);
   }
   entry.set_attempt(attempt_number, true);
-  entry.log();
+  entry.log(config_.status_metrics_enabled);
 
   std::string resp;
   curl.move_response(&resp);

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -21,6 +21,7 @@ struct HttpClientConfig {
   bool read_headers;
   bool read_body;
   bool verbose_requests;
+  bool status_metrics_enabled;
 };
 
 using HttpHeaders = std::unordered_map<std::string, std::string>;

--- a/spectator/http_client_test.cc
+++ b/spectator/http_client_test.cc
@@ -49,8 +49,8 @@ class TestRegistry : public Registry {
 };
 
 HttpClientConfig get_cfg(int read_to, int connect_to) {
-  return HttpClientConfig{absl::Milliseconds(connect_to),
-                          absl::Milliseconds(read_to), true, true, true};
+  return HttpClientConfig{absl::Milliseconds(connect_to), absl::Milliseconds(read_to),
+                          true, true, true, false, true};
 }
 
 TEST(HttpTest, Post) {

--- a/spectator/log_entry.h
+++ b/spectator/log_entry.h
@@ -19,15 +19,15 @@ class LogEntry {
 
   [[nodiscard]] auto start() const -> absl::Time { return start_; }
 
-  void log() {
-    PercentileTimer timer{registry_, std::move(id_), absl::Milliseconds(1),
-                          absl::Seconds(10)};
-    timer.Record(absl::Now() - start_);
+  void log(bool status_metrics_enabled) {
+    if (status_metrics_enabled) {
+      PercentileTimer timer{registry_, std::move(id_), absl::Milliseconds(1), absl::Seconds(10)};
+      timer.Record(absl::Now() - start_);
+    }
   }
 
   void set_status_code(int code) {
-    id_ = id_.WithTag(intern_str("http.status"),
-                      intern_str(fmt::format("{}", code)));
+    id_ = id_.WithTag(intern_str("http.status"), intern_str(fmt::format("{}", code)));
   }
 
   void set_attempt(int attempt_number, bool is_final) {


### PR DESCRIPTION
The purpose of this flag is to remove all common tags, so that users can override any common tags they wish, including `nf.app`, by providing them in the protocol line. Note that a proper environment is still required, so that the publish URI can be determined correctly.

This feature should only be used for secondary spectatord processes on an instance. A standard process should exist, so that atlas-system-agent metrics can be received and published.

When this feature is active, the publishing of internal status metrics is disabled, because we cannot attribute the metrics correctly in the absence of common tags.