### PR TITLE
add --ipv4_only parameter (default = false)

### DIFF
--- a/bench/parse_bench.cc
+++ b/bench/parse_bench.cc
@@ -24,7 +24,7 @@ static std::vector<std::string> get_measurements() {
 class dummy_server : public spectatord::Server {
  public:
   explicit dummy_server(spectator::Registry* registry)
-      : spectatord::Server(0, 0, "", registry) {}
+      : spectatord::Server(false, 0, 0, "", registry) {}
   void do_it() {
     auto measurements = get_measurements();
     for (const auto& s : measurements) {

--- a/bench/statsd_bench.cc
+++ b/bench/statsd_bench.cc
@@ -6,7 +6,7 @@
 class dummy_server : public spectatord::Server {
  public:
   explicit dummy_server(spectator::Registry* registry)
-      : spectatord::Server(0, 0, "", registry) {}
+      : spectatord::Server(false, 0, 0, "", registry) {}
   void parse_line(char* line) { parse_statsd(line); }
 };
 

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -67,6 +67,9 @@ ABSL_FLAG(bool, enable_socket, false,
 #endif
 ABSL_FLAG(bool, enable_statsd, false,
           "Enable statsd support.");
+ABSL_FLAG(bool, ipv4_only, false,
+          "Enable IPv4-only UDP listeners. This option should only be used in environments "
+          "where it is impossible to run IPv6.");
 ABSL_FLAG(std::string, metatron_dir, "",
           "Path to the Metatron certificates, which are used for external publishing. A number "
           "of well-known directories are searched by default. This option is only necessary "
@@ -173,7 +176,8 @@ auto main(int argc, char** argv) -> int {
   admin::AdminServer admin_server(registry, absl::GetFlag(FLAGS_admin_port).port);
   admin_server.Start();
 
-  spectatord::Server server{absl::GetFlag(FLAGS_port).port, statsd_port, socket_path, &registry};
+  spectatord::Server server{absl::GetFlag(FLAGS_ipv4_only), absl::GetFlag(FLAGS_port).port,
+                            statsd_port, socket_path, &registry};
   server.Start();
 
   return 0;

--- a/server/spectatord.h
+++ b/server/spectatord.h
@@ -10,8 +10,8 @@ namespace spectatord {
 
 class Server {
  public:
-  Server(int port_number, std::optional<int> statsd_port_number, std::optional<std::string> socket_path,
-         spectator::Registry* registry);
+  Server(bool ipv4_only, int port_number, std::optional<int> statsd_port_number,
+         std::optional<std::string> socket_path, spectator::Registry* registry);
   Server(const Server&) = delete;
   Server(Server&&) = delete;
   Server& operator=(const Server&) = delete;
@@ -23,6 +23,7 @@ class Server {
   void Stop();
 
  private:
+  bool ipv4_only_;
   int port_number_;
   std::optional<int> statsd_port_number_;
   std::optional<std::string> socket_path_;

--- a/server/spectatord_test.cc
+++ b/server/spectatord_test.cc
@@ -41,7 +41,7 @@ std::map<std::string, double> measurements_to_map(
 class test_server : public spectatord::Server {
  public:
   explicit test_server(spectator::Registry* registry)
-      : Server(0, 0, spectatord::kSocketNameDgram, registry),
+      : Server(false, 0, 0, spectatord::kSocketNameDgram, registry),
         registry_{registry} {}
   std::optional<std::string> parse_msg(char* msg) { return parse(msg); }
   std::optional<std::string> test_parse_statsd(char* buffer) {

--- a/server/udp_server.cc
+++ b/server/udp_server.cc
@@ -7,9 +7,11 @@ using asio::ip::udp;
 namespace spectatord {
 
 // NOLINTNEXTLINE(google-runtime-references)
-UdpServer::UdpServer(asio::io_context& io_context, int port_number,
+UdpServer::UdpServer(asio::io_context& io_context, bool ipv4_only, int port_number,
                      handler_t message_handler)
-    : udp_socket_{io_context, udp::endpoint(udp::v6(), port_number)},
+    : udp_socket_{io_context, udp::endpoint([&ipv4_only]() -> udp {
+                    if (ipv4_only) return udp::v4(); else return udp::v6();
+                  }() , port_number)},
       message_handler_(std::move(message_handler)) {
   asio::socket_base::receive_buffer_size option{max_buffer_size()};
   try {

--- a/server/udp_server.h
+++ b/server/udp_server.h
@@ -7,7 +7,7 @@ namespace spectatord {
 class UdpServer {
  public:
   // NOLINTNEXTLINE(google-runtime-references)
-  UdpServer(asio::io_context& io_context, int port_number,
+  UdpServer(asio::io_context& io_context, bool ipv4_only, int port_number,
             handler_t message_handler);
 
   void Start() { start_udp_receive(); }


### PR DESCRIPTION
There are some systems which cannot run IPv6 at all, and the previous default behavior of spectatord meant that the process crashes when attempting to listen on a udp6 socket.

This change adds an optional parameter --ipv4_only, defaulting to false, which will configure the socket listener to use udp4 instead of udp6.

When using the udp6 socket, the server is capable of receiving udp packets from IPv4 on dual-stacked instances with IPv4-mapped IPv6 addresses enabled.