### PR TITLE
log parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ source venv/bin/activate
 ln -s cmake-build cmake-build-debug
 
 ./build.sh  # [clean|clean --force|skiptest]
+
+# run the binary locally
+./cmake-build/bin/spectatord_main --enable_external --no_common_tags
+
+# test publish
+echo "c:server.numRequests,nf.app=spectatord_$USER,id=failed:1" | nc -u -w0 localhost 1234
+echo "c:server.numRequests,nf.app=spectatord_$USER,id=success:1" | nc -u -w0 localhost 1234
+
+# parse errors
+echo ":server.numRequests,nf.app=spectatord_$USER,id=failed:1" | nc -u -w0 localhost 1234
+echo "c:server.numRequests,nf.app=spectatord_$USER,id=failed" | nc -u -w0 localhost 1234
+echo "c::1" | nc -u -w0 localhost 1234
 ```
 
 * CLion > Preferences > Plugins > Marketplace > Conan > Install

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
+from typing import Optional
 
 from conans import ConanFile
 from conans.tools import download, unzip, check_sha256
@@ -9,10 +10,10 @@ from conans.tools import download, unzip, check_sha256
 
 @dataclass
 class NflxConfig:
-    internal: str = os.getenv("NFLX_INTERNAL")
-    source_host: str = os.getenv("NFLX_SOURCE_HOST")
-    ssl_cert: str = os.getenv("NFLX_SSL_CERT")
-    ssl_key: str = os.getenv("NFLX_SSL_KEY")
+    internal: Optional[str] = os.getenv("NFLX_INTERNAL")
+    source_host: Optional[str] = os.getenv("NFLX_SOURCE_HOST")
+    ssl_cert: Optional[str] = os.getenv("NFLX_SSL_CERT")
+    ssl_key: Optional[str] = os.getenv("NFLX_SSL_KEY")
 
 class SpectatorDConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -86,12 +87,12 @@ class SpectatorDConan(ConanFile):
 
     def get_netflix_spectator_cppconf(self, nflx_cfg: NflxConfig) -> None:
         repo = "corp/cldmta-netflix-spectator-cppconf"
-        commit = "190785a2205e96c71646a4f3dd6b8f5154e9a9ba"
+        commit = "a225b1aa20b74ecffa8c1cdb5f884b2d792809d2"
         zip_name = repo.replace("corp/", "") + f"-{commit}.zip"
 
         self.maybe_remove_file(zip_name)
         self.download(nflx_cfg, repo, commit, zip_name)
-        check_sha256(zip_name, "50d8641f2a38d4682c33fbb4a073f9e6679589e635ced09caadc54a7f55c26a5")
+        check_sha256(zip_name, "b8a202ccafb5389dbda02cb9750cb0bfcd44369c69e015eb55a10b5f8759d73a")
 
         dir_name = repo.replace("corp/", "")
         self.maybe_remove_dir(dir_name)

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -513,21 +513,27 @@ auto Server::parse_line(const char* buffer) -> std::optional<std::string> {
     if (extra <= 0) {
       auto idx = p - buffer;
       if (type == 'g') {
-        return fmt::format("Invalid ttl specified for gauge at index {}", idx);
+        auto msg = fmt::format("Invalid ttl specified for gauge at index {}", idx);
+        Logger()->info(fmt::format("Parse error for '{}': {}", buffer, msg));
+        return msg;
       } else if (type == 'X') {
-        return fmt::format(
-            "Invalid timestamp specified for monotonic sampled source at index {}", idx);
+        auto msg = fmt::format("Invalid timestamp specified for monotonic sampled source at index {}", idx);
+        Logger()->info(fmt::format("Parse error for '{}': {}", buffer, msg));
+        return msg;
       }
     }
     p = end_ttl;
   }
   if (*p != ':') {
-    return fmt::format("Expecting separator ':' at index {}", p - buffer);
+    auto msg = fmt::format("Expecting separator ':' at index {}", p - buffer);
+    Logger()->info(fmt::format("Parse error for '{}': {}", buffer, msg));
+    return msg;
   }
   ++p;
   std::string err_msg;
   auto measurement = get_measurement(type, p, &err_msg);
   if (!measurement) {
+    Logger()->info(fmt::format("Parse error for '{}': {}", buffer, err_msg));
     return err_msg;
   }
 


### PR DESCRIPTION
There was no feedback mechanism for poorly formatted protocol messages, because the errors were not logged. This change logs those errors, at INFO level, so that we do not trigger exception alerts.

External publishing now needs a slightly longer connect timeout, in order for connections to succeed. Update the netflix-spectatord-cppconf library to make this happen.