### PR TITLE
update metatron config library

### DIFF
--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -2,10 +2,13 @@
 #include "util/logger.h"
 #include "spectatord.h"
 #include "spectator/registry.h"
+#include "spectator/version.h"
 #include <cstdlib>
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "absl/flags/internal/program_name.h"
 #include "absl/flags/usage.h"
+#include "absl/flags/usage_config.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
 #include "admin/admin_server.h"
@@ -96,12 +99,15 @@ ABSL_FLAG(bool, verbose_http, false,
 
 auto main(int argc, char** argv) -> int {
   auto logger = Logger();
+
   auto signals = backward::SignalHandling::make_default_signals();
   // default signals except SIGABRT
-  signals.erase(std::remove(signals.begin(), signals.end(), SIGABRT),
-                signals.end());
+  signals.erase(std::remove(signals.begin(), signals.end(), SIGABRT), signals.end());
   backward::SignalHandling sh{signals};
 
+  auto usage_config = absl::flags_internal::GetUsageConfig();
+  usage_config.version_string = []() { return fmt::format("spectatord/{}\n", VERSION); };
+  absl::SetFlagsUsageConfig(usage_config);
   absl::SetProgramUsageMessage("A daemon that listens for metrics and reports them to Atlas.");
   absl::ParseCommandLine(argc, argv);
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,7 +61,8 @@ class SpectatorDConan(ConanFile):
     @staticmethod
     def download(nflx_cfg: NflxConfig, repo: str, commit: str, zip_name: str) -> None:
         subprocess.run([
-            "curl", "-s", "-k", "-L",
+            "curl", "-s", "-L",
+            "--connect-timeout", "5",
             "--cert", nflx_cfg.ssl_cert,
             "--key", nflx_cfg.ssl_key,
             "-H", "Accept: application/vnd.github+json",
@@ -105,12 +106,12 @@ class SpectatorDConan(ConanFile):
 
     def get_spectatord_metatron(self, nflx_cfg: NflxConfig) -> None:
         repo = "corp/cldmta-spectatord-metatron"
-        commit = "544fec6b794e46da0af174062a35567a9d462e5f"
+        commit = "0adc171544dd4f30d445a8463176082a98be8070"
         zip_name = repo.replace("corp/", "") + f"-{commit}.zip"
 
         self.maybe_remove_file(zip_name)
         self.download(nflx_cfg, repo, commit, zip_name)
-        check_sha256(zip_name, "edb0aebd7b391f72242fae0ee08c7a0ae86170743dffc49166f2f3e8a7062185")
+        check_sha256(zip_name, "a8be6a7ac2c8704f4b0c6d121de64db96855354eea2ef463d3e3c629c459fc04")
 
         dir_name = repo.replace("corp/", "")
         self.maybe_remove_dir(dir_name)


### PR DESCRIPTION
* Fixes search paths for certificates on MacOS for non-interactive systems.
* Add a proper version string to the binary.
* Internal downloads no longer require the `-k` option.