### PR TITLE
downgrade from gcc-13 to gcc-11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update && sudo apt-get install -y binutils-dev g++-13 libiberty-dev
+          sudo apt-get update && sudo apt-get install -y binutils-dev g++-11 libiberty-dev
 
       - name: Build
         run: |

--- a/build.sh
+++ b/build.sh
@@ -36,8 +36,9 @@ fi
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   source /etc/os-release
   if [[ "$NAME" == "Ubuntu" ]]; then
-    if [[ -z "$CC" ]]; then export CC=gcc-13; fi
-    if [[ -z "$CXX" ]]; then export CXX=g++-13; fi
+    # gcc version cannot be updated without breaking standard bionic images
+    if [[ -z "$CC" ]]; then export CC=gcc-11; fi
+    if [[ -z "$CXX" ]]; then export CXX=g++-11; fi
   fi
 fi
 


### PR DESCRIPTION
Internally, bumping from gcc-11 to gcc-13 requires an update of libstdc++ from `8.4.0-1ubuntu1~18.04` to `13.1.0-8ubuntu1~18.04`. Our standard images cannot accept this change, so we must downgrade.