### PR TITLE
static link libstdc++ and restore gcc-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update && sudo apt-get install -y binutils-dev g++-11 libiberty-dev
+          sudo apt-get update && sudo apt-get install -y binutils-dev g++-13 libiberty-dev
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ else()
         Backward::Backward
     )
 endif()
+# required to allow running on older systems, such as bionic
+target_link_options(spectatord_main PRIVATE "-static-libstdc++")
 
 #-- metrics_gen executable
 add_executable(metrics_gen

--- a/build.sh
+++ b/build.sh
@@ -36,9 +36,8 @@ fi
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   source /etc/os-release
   if [[ "$NAME" == "Ubuntu" ]]; then
-    # gcc version cannot be updated without breaking standard bionic images
-    if [[ -z "$CC" ]]; then export CC=gcc-11; fi
-    if [[ -z "$CXX" ]]; then export CXX=g++-11; fi
+    if [[ -z "$CC" ]]; then export CC=gcc-13; fi
+    if [[ -z "$CXX" ]]; then export CXX=g++-13; fi
   fi
 fi
 
@@ -52,8 +51,7 @@ if [[ ! -d $BUILD_DIR ]]; then
   if [[ "$BUILD_TYPE" == "Debug" ]]; then
     conan install . --output-folder="$BUILD_DIR" --build="*" --settings=build_type="$BUILD_TYPE" --profile=./sanitized
   else
-    # build "*" (all) instead of "missing" to avoid "unsupported GNU_PROPERTY_TYPE" errors with gcc-11
-    conan install . --output-folder="$BUILD_DIR" --build="*"
+    conan install . --output-folder="$BUILD_DIR" --build=missing
   fi
 
   # this switch is necessary for internal centos builds


### PR DESCRIPTION
The libstdc++6 versions can vary much more dramatically than the libc6 versions on a given system, so statically link this library.

This was the cause of issues running on bionic, not gcc-13.