### PR TITLE
C++23BuildFixes

### DIFF
--- a/spectator/id.h
+++ b/spectator/id.h
@@ -62,10 +62,6 @@ class Id {
     return WithStat(stat);
   }
 
-  friend auto operator<<(std::ostream& os, const Id& id) -> std::ostream& {
-    return os << fmt::format("{}", id);
-  }
-
   friend struct std::hash<Id>;
 
   friend struct std::hash<std::shared_ptr<Id>>;
@@ -122,3 +118,7 @@ template <> struct fmt::formatter<spectator::Id>: formatter<std::string_view> {
     return fmt::format_to(ctx.out(), "Id({}, {})", id.Name(), id.GetTags());
   }
 };
+
+inline auto operator<<(std::ostream& os, const spectator::Id& id) -> std::ostream& {
+  return os << fmt::format("{}", id);
+}

--- a/spectator/measurement.h
+++ b/spectator/measurement.h
@@ -25,10 +25,6 @@ class Measurement {
   }
 };
 
-inline auto operator<<(std::ostream& os, const Measurement& m) -> std::ostream& {
-  return os << fmt::format("{}", m);
-}
-
 using Measurements = std::vector<Measurement>;
 
 }  // namespace spectator
@@ -39,3 +35,7 @@ template <> struct fmt::formatter<spectator::Measurement>: formatter<std::string
     return fmt::format_to(ctx.out(), "Measurement{{{}, {}}}", m.id, m.value);
   }
 };
+
+inline auto operator<<(std::ostream& os, const spectator::Measurement& m) -> std::ostream& {
+  return os << fmt::format("{}", m);
+}

--- a/spectator/tags.h
+++ b/spectator/tags.h
@@ -204,10 +204,6 @@ class Tags {
   }
 };
 
-inline auto operator<<(std::ostream& os, const Tags& tags) -> std::ostream& {
-  return os << fmt::format("{}", tags);
-}
-
 }  // namespace spectator
 
 // formatter: statistic->count
@@ -216,3 +212,7 @@ template <> struct fmt::formatter<spectator::Tag>: formatter<std::string_view> {
       return fmt::format_to(ctx.out(), "{}->{}", tag.key, tag.value);
   }
 };
+
+inline auto operator<<(std::ostream& os, const spectator::Tags& tags) -> std::ostream& {
+  return os << fmt::format("{}", tags);
+}


### PR DESCRIPTION
## Intro:

This is a fix that ensures your project can successfully build with `C++23` should you choose to upgrade. While exploring the project, I noticed that switching to a newer C++ version caused build failures. This pull request addresses those issues, allowing you to safely bump your `CMAKE_CXX_STANDARD` to `23` if desired.

## Technical Changes:

Here is a screenshot of the build errors I was encountering.

<img width="1916" alt="C++23BuildErrors" src="https://github.com/user-attachments/assets/63f45cbf-fbb0-4c05-9246-96ca7960f874" />


You can easily reproduce them in the docker container with the following changes I have in my branch [BuildFailuresC++23](https://github.com/ecbadeaux/spectatord/tree/BuildFailuresC%2B%2B23).


After inspecting the build errors, I was able to see that you were attempting to overload the `stream insertion` operators for the classes `Tag`, `Id`, and `Measurement`. In each of these classes, you were defining the implementation for the stream operator, which inherently would call the `templated fmt::format specialization` for each class. The issue is that the definition for each `stream insertion` would attempt to call the `format specialization` before it had been defined. In order to get around this error, you need to define the `template` before defining the `stream insertion` because of their dependencies.

I also removed the unneeded `friend` qualifier for the `Id` stream operator.

After making the changes above, I was able to get the project to build with C++23 :tada:.

I've created a branch [here](https://github.com/ecbadeaux/spectatord/tree/C%2B%2B23BuildFixesWithTest) that has an additional dummy unit test to ensure C++23 features are now working.  This C++23 feature is only available in gcc-14, but, nevertheless, the project will now build with certain C++23 features if supported by the compiler version.

I did not bump the `CMAKE_CXX_STANDARD`, but if you would like me to, let me know 😄 
