### PR TITLE
fix `spectator.measurements` metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 CMakeUserPresets.json
 cmake-build-debug/
 cmake-build/
+conan_provider.cmake
 metatron/auth_context.pb.cc
 metatron/auth_context.pb.h
 metatron/auth_context.proto

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -111,15 +111,22 @@ auto main(int argc, char** argv) -> int {
 
   auto cfg = GetSpectatorConfig();
 
-  auto maybe_agg_uri = absl::GetFlag(FLAGS_uri);
-  if (absl::GetFlag(FLAGS_debug)) {
-    cfg->uri = "https://atlas-aggr-dev.us-east-1.ieptest.netflix.net/api/v4/update";
-  } else if (!maybe_agg_uri.empty()) {
-    cfg->uri = std::move(maybe_agg_uri);
-  } else if (absl::GetFlag(FLAGS_enable_external)) {
+  if (absl::GetFlag(FLAGS_enable_external)) {
     cfg->external_enabled = true;
     cfg->metatron_dir = absl::GetFlag(FLAGS_metatron_dir);
+    // provide a reasonable default for external publishing
     cfg->uri = cfg->external_uri;
+  }
+
+  if (!absl::GetFlag(FLAGS_uri).empty()) {
+    // allow overriding the uri for both standard and external publishing
+    cfg->uri = absl::GetFlag(FLAGS_uri);
+  }
+
+  if (absl::GetFlag(FLAGS_debug)) {
+    // when running in debug mode, never publish externally
+    cfg->external_enabled = false;
+    cfg->uri = "https://atlas-aggr-dev.us-east-1.ieptest.netflix.net/api/v4/update";
   }
 
   if (absl::GetFlag(FLAGS_verbose_http)) {

--- a/conanfile.py
+++ b/conanfile.py
@@ -90,12 +90,12 @@ class SpectatorDConan(ConanFile):
 
     def get_netflix_spectator_cppconf(self, nflx_cfg: NflxConfig) -> None:
         repo = "corp/cldmta-netflix-spectator-cppconf"
-        commit = "a76058e12a5e0928cc0a36acb1bfb8e045f9d589"
+        commit = "aa12add4ba33ac08002573d1a6563cad1b620e08"
         zip_name = repo.replace("corp/", "") + f"-{commit}.zip"
 
         self.maybe_remove_file(zip_name)
         self.download(nflx_cfg, repo, commit, zip_name)
-        check_sha256(self, zip_name, "9ffc2190f0ee676ddd9af31fcdd9a05cfbd990674101d7c8958638a0a432bdef")
+        check_sha256(self, zip_name, "7d72078e5e209ebaa1e7e861edf815c212353bcf2e8c9bf20de5304a2f9a7271")
 
         dir_name = repo.replace("corp/", "")
         self.maybe_remove_dir(dir_name)

--- a/spectator/log_entry.h
+++ b/spectator/log_entry.h
@@ -12,7 +12,7 @@ class LogEntry {
            const std::string& url)
       : registry_{registry},
         start_{absl::Now()},
-        id_{Id::Of("ipc.client.call", {{"owner", "spectatord"},
+        id_{Id::Of("ipc.client.call", {{"nf.process", "spectatord"},
                                        {"ipc.endpoint", PathFromUrl(url)},
                                        {"http.method", method},
                                        {"http.status", "-1"}})} {}

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -12,7 +12,7 @@ Registry::Registry(std::unique_ptr<Config> config,
       meter_ttl_{absl::ToInt64Nanoseconds(config->meter_ttl)},
       config_{std::move(config)},
       logger_{std::move(logger)},
-      registry_size_{GetDistributionSummary("spectator.registrySize", Tags{{"owner", "spectatord"}})},
+      registry_size_{GetDistributionSummary("spectator.registrySize", Tags{{"nf.process", "spectatord"}})},
       publisher_(this) {
   if (meter_ttl_ == 0) {
     meter_ttl_ = int64_t(15) * 60 * 1000 * 1000 * 1000;

--- a/spectator/registry_test.cc
+++ b/spectator/registry_test.cc
@@ -184,7 +184,8 @@ TEST(Registry, DistSummary_Size) {
   r.GetCounter("bar")->Increment();
   // we have 4 measurements from the timer + 1 from the counter
   r.Measurements();
-  EXPECT_DOUBLE_EQ(r.GetDistributionSummary("spectator.registrySize", Tags{{"owner", "spectatord"}})->TotalAmount(), 5.0);
+  EXPECT_DOUBLE_EQ(r.GetDistributionSummary("spectator.registrySize",
+    Tags{{"nf.process", "spectatord"}})->TotalAmount(), 5.0);
 }
 
 TEST(Registry, DeleteMeters) {


### PR DESCRIPTION
* The `spectator.measurements` internal status metrics were not being published on 200 OK responses, only when partial errors were observed. This change fixes that, so that we always publish the sent metrics counter on 200 OK.
* The `spectator.measurements` metrics were using the `owner` tag to identify the source of the metrics. Our internal dashboards use the `nf.process` tag for this purpose, so we want to use that instead.
* The `ipc.client.call` metrics were using the `owner` tag to identify the source of the metrics. The `owner` tag is better considered to be a way to identify a source library, when there could be many sources of a metric. It is better to use `nf.process` to identify these metrics.
* The `spectator.registrySize` metrics were using the `owner` tag to identify the source of the metrics. This was swapped to `nf.process`.
* We do not want to set the `nf.process` tag with an environment variable for `spectatord`, because there are many processes that send metrics through it, each of which may want to set that tag independently. Thus, we set the `nf.process` tag manually in the status metrics.
* The internal configuration library version was updated, so that we default to the test endpoint for external publishing.
* The command line parameter parsing was updated, so that the `--uri` parameter can be used to switch back to the prod endpoint, for external publishing, if there is a need.