### PR TITLE
Flush Metrics For AWS Lambda

### DIFF
--- a/admin/admin_server_test.cc
+++ b/admin/admin_server_test.cc
@@ -22,6 +22,8 @@ constexpr int kDefaultPort = 8080;
 std::unique_ptr<spectator::Config> GetConfiguration() {
   auto config = std::make_unique<spectator::Config>();
   config->age_gauge_limit = 10;
+  config->batch_size = 10000; // Internal NFLX default
+  config->frequency = absl::Seconds(5);  // Internal NFLX default
   return config;
 }
 
@@ -74,13 +76,17 @@ class AdminServerTest : public testing::Test {
     auto logger = spectatord::Logger();
     logger->info("Shutdown test instance of AdminServer");
 
-    server->Stop();
-    delete server;
-    server = nullptr;
+    if (server != nullptr) {
+      server->Stop();
+      delete server;
+      server = nullptr;
+    }
 
-    registry->Stop();
-    delete registry;
-    registry = nullptr;
+    if (registry != nullptr) {
+      registry->Stop();
+      delete registry;
+      registry = nullptr;
+    }
   }
 
   static spectator::Registry *registry;

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -34,7 +34,7 @@ class Config {
   absl::Duration read_timeout;
   absl::Duration connect_timeout;
   int batch_size{};
-  absl::Duration frequency;
+  absl::Duration frequency{absl::Seconds(5)};
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
   size_t age_gauge_limit{};

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -34,7 +34,7 @@ class Config {
   absl::Duration read_timeout;
   absl::Duration connect_timeout;
   int batch_size{};
-  absl::Duration frequency{absl::Seconds(5)};
+  absl::Duration frequency{};
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
   size_t age_gauge_limit{};

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -34,7 +34,7 @@ class Config {
   absl::Duration read_timeout;
   absl::Duration connect_timeout;
   int batch_size{};
-  absl::Duration frequency{};
+  absl::Duration frequency;
   absl::Duration expiration_frequency;
   absl::Duration meter_ttl;
   size_t age_gauge_limit{};

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -351,7 +351,6 @@ class Publisher {
     auto start = absl::Now();
     HttpClient client{registry_, std::move(http_cfg)};
     auto batch_size = static_cast<std::vector<Measurement>::difference_type>(cfg.batch_size);
-    
     auto measurements = registry_->Measurements();
 
     if (!cfg.is_enabled() || measurements.empty()) {

--- a/spectator/sample_config.cc
+++ b/spectator/sample_config.cc
@@ -2,11 +2,13 @@
 
 namespace spectator {
 
-// used in tests
+// used in tests and non NFLX deployments
 auto GetConfiguration() -> std::unique_ptr<Config> {
   auto config = std::make_unique<Config>();
   config->age_gauge_limit = 10;
   config->process_name = "spectatord";
+  config->batch_size = 10000; // Internal NFLX default
+  config->frequency = absl::Seconds(5); // Internal NFLX default
   return config;
 }
 


### PR DESCRIPTION
Ensures that any metrics accumulated since the last periodic send are flushed before the Publisher is destroyed, preventing potential data loss during application shutdown. The flush operation is called in the Stop() method with proper exception handling and logging. 

Add batch_size validation in Publisher::Start() to prevent infinite loop when batch_size <= 0

Fix sample configuration to use proper batch_size (10000) and frequency (5 seconds) which are the internal config defaults