### PR TITLE
Fallback sink

### DIFF
--- a/util/insight_log_sinks.h
+++ b/util/insight_log_sinks.h
@@ -20,9 +20,9 @@ inline auto create_insight_logs_sink(const std::string& host, int port) -> spdlo
 	return sink;
 }
 
-inline auto create_insight_logs_unix_sink(const std::string& socket_path) -> spdlog::sink_ptr
+inline auto create_insight_logs_unix_sink(const std::string& socket_path, spdlog::sink_ptr fallback = nullptr) -> spdlog::sink_ptr
 {
-	spdlog::sinks::unix_sink_config cfg{socket_path};
+	spdlog::sinks::unix_sink_config cfg{socket_path, std::move(fallback)};
 
 	auto sink = std::make_shared<spdlog::sinks::unix_sink_mt>(cfg);
 	sink->set_formatter(std::make_unique<JsonLogFormatter>());

--- a/util/logger.cc
+++ b/util/logger.cc
@@ -31,7 +31,8 @@ Logger::Logger(const std::string& name, bool enable_insight_logs)
 		struct stat sb;
 		if (stat(kInsightLogsSocketPath, &sb) == 0 && (sb.st_mode & S_IFSOCK) != 0)
 		{
-			sinks.push_back(create_insight_logs_unix_sink(kInsightLogsSocketPath));
+			auto fallback = create_insight_logs_sink("127.0.0.1", 1552);
+			sinks.push_back(create_insight_logs_unix_sink(kInsightLogsSocketPath, std::move(fallback)));
 			insight_logs_dest = kInsightLogsSocketPath;
 		}
 		else

--- a/util/unix_socket_log_sink.h
+++ b/util/unix_socket_log_sink.h
@@ -17,9 +17,10 @@ namespace sinks {
 
 struct unix_sink_config {
 	std::string path;
+	spdlog::sink_ptr fallback;
 
-	explicit unix_sink_config(std::string socket_path)
-		: path{std::move(socket_path)}
+	explicit unix_sink_config(std::string socket_path, spdlog::sink_ptr fallback_sink = nullptr)
+		: path{std::move(socket_path)}, fallback{std::move(fallback_sink)}
 	{
 	}
 };
@@ -29,6 +30,7 @@ class unix_sink : public spdlog::sinks::base_sink<Mutex> {
    public:
 	explicit unix_sink(unix_sink_config sink_config)
 		: config_{std::move(sink_config)},
+		  fallback_{config_.fallback},
 		  endpoint_{config_.path}
 	{
 		asio::error_code ec;
@@ -60,7 +62,18 @@ class unix_sink : public spdlog::sinks::base_sink<Mutex> {
 		if (ec && ec != asio::error::would_block
 		       && ec != asio::error::no_buffer_space)
 		{
-			throw_spdlog_ex("unix_sink: send_to failed: " + ec.message());
+			// If a fallback sink is provided, log the message there instead.
+			if (fallback_)
+			{
+				spdlog::details::log_msg warn_msg(spdlog::source_loc{}, "", spdlog::level::err,
+				    "unix_sink: OTel Collector socket is down (" + ec.message() + "), falling back to TCP");
+				fallback_->log(warn_msg);
+				fallback_->log(msg);
+			}
+			else
+			{
+				throw_spdlog_ex("unix_sink: send_to failed: " + ec.message());
+			}
 		}
 	}
  
@@ -68,6 +81,7 @@ class unix_sink : public spdlog::sinks::base_sink<Mutex> {
 
    private:
 	unix_sink_config config_;
+	spdlog::sink_ptr fallback_;
 	asio::io_context io_context_;
 	asio::local::datagram_protocol::socket socket_{io_context_};
 	asio::local::datagram_protocol::endpoint endpoint_;

--- a/util/unix_socket_log_sink.h
+++ b/util/unix_socket_log_sink.h
@@ -69,7 +69,7 @@ class unix_sink : public spdlog::sinks::base_sink<Mutex> {
 			if (fallback_)
 			{
 				std::string warn_text = "unix_sink: OTel Collector socket is down (" + ec.message() + "), falling back to TCP";
-				spdlog::details::log_msg warn_msg(spdlog::source_loc{}, "", spdlog::level::err, warn_text);
+				spdlog::details::log_msg warn_msg(spdlog::source_loc{}, msg.logger_name, spdlog::level::err, warn_text);
 				std::cerr << warn_text << std::endl;
 				fallback_->log(warn_msg);
 				fallback_->log(msg);

--- a/util/unix_socket_log_sink.h
+++ b/util/unix_socket_log_sink.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 
 #include <asio.hpp>
@@ -62,11 +63,14 @@ class unix_sink : public spdlog::sinks::base_sink<Mutex> {
 		if (ec && ec != asio::error::would_block
 		       && ec != asio::error::no_buffer_space)
 		{
-			// If a fallback sink is provided, log the message there instead.
+			// OTel Collector early socket is unreachable. Log the error to stderr
+			// (visible in journald) and route this message through the TCP
+			// fallback sink at 127.0.0.1:1552.
 			if (fallback_)
 			{
-				spdlog::details::log_msg warn_msg(spdlog::source_loc{}, "", spdlog::level::err,
-				    "unix_sink: OTel Collector socket is down (" + ec.message() + "), falling back to TCP");
+				std::string warn_text = "unix_sink: OTel Collector socket is down (" + ec.message() + "), falling back to TCP";
+				spdlog::details::log_msg warn_msg(spdlog::source_loc{}, "", spdlog::level::err, warn_text);
+				std::cerr << warn_text << std::endl;
 				fallback_->log(warn_msg);
 				fallback_->log(msg);
 			}


### PR DESCRIPTION
Add hardening around socket availability. The unix socket log sink now falls back to TCP (127.0.0.1:1552) when the OTel Collector early socket is unreachable, logging the error to both stderr (journald) and the fallback sink. 