### PR TITLE
Add configurable metric publishing policies

### DIFF
--- a/admin/admin_server.cc
+++ b/admin/admin_server.cc
@@ -53,9 +53,30 @@ void GET_config(HTTPServerRequest& req, HTTPServerResponse& res, const spectator
 		common_tags->set(pair.first, pair.second);
 	}
 
+	Poco::JSON::Array::Ptr policies = new Poco::JSON::Array(true);
+	for (const auto& rule : config.policies)
+	{
+		Object::Ptr rule_obj = new Object(true);
+		Object::Ptr match_tags = new Object(true);
+		for (const auto& pair : rule.match_tags)
+		{
+			match_tags->set(pair.first, pair.second);
+		}
+		rule_obj->set("match_tags", match_tags);
+
+		Poco::JSON::Array::Ptr omit_common_tags = new Poco::JSON::Array(true);
+		for (const auto& tag : rule.omit_common_tags)
+		{
+			omit_common_tags->add(tag);
+		}
+		rule_obj->set("omit_common_tags", omit_common_tags);
+		policies->add(rule_obj);
+	}
+
 	obj->set("age_gauge_limit", config.age_gauge_limit);
 	obj->set("batch_size", config.batch_size);
 	obj->set("common_tags", common_tags);
+	obj->set("policies", policies);
 	obj->set("connect_timeout", ToDoubleMilliseconds(config.connect_timeout));
 	obj->set("expiration_frequency", ToDoubleMilliseconds(config.expiration_frequency));
 	obj->set("external_enabled", config.external_enabled);

--- a/admin/admin_server_test.cc
+++ b/admin/admin_server_test.cc
@@ -189,10 +189,19 @@ TEST_F(AdminServerTest, GET_config)
 	Var result{parser.parse(rr)};
 	Object::Ptr object = result.extract<Object::Ptr>();
 
-	std::vector<std::string> expected_keys{
-	    "age_gauge_limit",        "batch_size", "common_tags",  "connect_timeout", "expiration_frequency",
-	    "external_enabled",       "frequency",  "metatron_dir", "meter_ttl",       "read_timeout",
-	    "status_metrics_enabled", "uri"};
+	std::vector<std::string> expected_keys{"age_gauge_limit",
+	                                      "batch_size",
+	                                      "common_tags",
+	                                      "connect_timeout",
+	                                      "expiration_frequency",
+	                                      "external_enabled",
+	                                      "frequency",
+	                                      "metatron_dir",
+	                                      "meter_ttl",
+	                                      "policies",
+	                                      "read_timeout",
+	                                      "status_metrics_enabled",
+	                                      "uri"};
 	std::vector<std::string> found_keys;
 
 	for (auto& it : *object)

--- a/bin/spectatord_main.cc
+++ b/bin/spectatord_main.cc
@@ -7,11 +7,14 @@
 #include "absl/flags/usage.h"
 #include "absl/flags/usage_config.h"
 #include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
 #include "absl/time/time.h"
 #include "backward.hpp"
 
 #include <cstdlib>
 #include <fmt/ranges.h>
+#include <optional>
+#include <string_view>
 
 auto GetSpectatorConfig() -> std::unique_ptr<spectator::Config>;
 
@@ -48,6 +51,88 @@ auto AbslParseFlag(absl::string_view text, PortNumber* p, std::string* error) ->
 	return true;
 }
 
+static auto trim_copy(std::string_view value) -> std::string
+{
+	auto stripped = absl::StripAsciiWhitespace(value);
+	return {stripped.data(), stripped.size()};
+}
+
+static auto starts_with(std::string_view value, std::string_view prefix) -> bool
+{
+	return value.size() >= prefix.size() && value.compare(0, prefix.size(), prefix) == 0;
+}
+
+static auto parse_policies(std::string_view value, std::string* error)
+    -> std::optional<std::vector<spectator::PolicyRule>>
+{
+	std::vector<spectator::PolicyRule> rules;
+	for (auto raw_rule : absl::StrSplit(value, ';'))
+	{
+		auto rule_text = trim_copy(raw_rule);
+		if (rule_text.empty())
+		{
+			continue;
+		}
+
+		auto arrow_pos = rule_text.find("->");
+		if (arrow_pos == std::string::npos)
+		{
+			*error = fmt::format("missing '->' in policy rule '{}'", rule_text);
+			return std::nullopt;
+		}
+
+		auto matcher_text = trim_copy(std::string_view{rule_text}.substr(0, arrow_pos));
+		auto action_text = trim_copy(std::string_view{rule_text}.substr(arrow_pos + 2));
+		if (!starts_with(matcher_text, "tag:"))
+		{
+			*error = fmt::format("policy matcher must start with 'tag:' in rule '{}'", rule_text);
+			return std::nullopt;
+		}
+		if (!starts_with(action_text, "omit:"))
+		{
+			*error = fmt::format("policy action must start with 'omit:' in rule '{}'", rule_text);
+			return std::nullopt;
+		}
+
+		spectator::PolicyRule rule;
+		for (auto raw_matcher : absl::StrSplit(std::string_view{matcher_text}.substr(4), ','))
+		{
+			auto matcher = trim_copy(raw_matcher);
+			if (starts_with(matcher, "tag:"))
+			{
+				matcher = trim_copy(std::string_view{matcher}.substr(4));
+			}
+			auto equals_pos = matcher.find('=');
+			if (equals_pos == std::string::npos || equals_pos == 0 || equals_pos == matcher.size() - 1)
+			{
+				*error = fmt::format("policy matcher must be key=value in rule '{}'", rule_text);
+				return std::nullopt;
+			}
+			rule.match_tags[trim_copy(std::string_view{matcher}.substr(0, equals_pos))] =
+			    trim_copy(std::string_view{matcher}.substr(equals_pos + 1));
+		}
+
+		for (auto raw_tag : absl::StrSplit(std::string_view{action_text}.substr(5), ','))
+		{
+			auto tag = trim_copy(raw_tag);
+			if (tag.empty())
+			{
+				*error = fmt::format("policy omit action has an empty tag in rule '{}'", rule_text);
+				return std::nullopt;
+			}
+			rule.omit_common_tags.emplace_back(std::move(tag));
+		}
+
+		if (rule.match_tags.empty() || rule.omit_common_tags.empty())
+		{
+			*error = fmt::format("policy rule '{}' must have matchers and omitted common tags", rule_text);
+			return std::nullopt;
+		}
+		rules.emplace_back(std::move(rule));
+	}
+	return rules;
+}
+
 ABSL_FLAG(PortNumber, admin_port, PortNumber(1234), "Port number for the admin server.");
 ABSL_FLAG(size_t, age_gauge_limit, 1000, "The maximum number of age gauges that may be reported by this process.");
 ABSL_FLAG(std::string, common_tags, "",
@@ -78,6 +163,10 @@ ABSL_FLAG(std::string, metatron_dir, "",
 ABSL_FLAG(absl::Duration, meter_ttl, absl::Minutes(15), "Meter TTL: expire meters after this period of inactivity.");
 ABSL_FLAG(absl::Duration, frequency, absl::Seconds(5),
           "Reporting frequency: how often metrics are flushed to the Atlas aggregator.");
+ABSL_FLAG(std::string, policies, "",
+          "Policy rules for per-metric common-tag handling. Grammar: "
+          "tag:<key>=<value>[,<key>=<value>]->omit:<common-tag>[,<common-tag>];... "
+          "Example: tag:nf.process=spark-executor->omit:nf.node. Use 'none' to clear configured rules.");
 ABSL_FLAG(bool, no_common_tags, false,
           "No common tags will be provided for metrics. Since no common tags are available, no "
           "internal status metrics will be recorded. Only use this feature for special cases "
@@ -164,6 +253,28 @@ auto main(int argc, char** argv) -> int
 		}
 		logger->info("Using common tags: {}", common_tags);
 		cfg->common_tags = std::move(common_tags);
+	}
+
+	auto maybe_policies = absl::GetFlag(FLAGS_policies);
+	if (!maybe_policies.empty())
+	{
+		if (maybe_policies == "none")
+		{
+			logger->info("Clearing policy rules");
+			cfg->policies.clear();
+		}
+		else
+		{
+			std::string error;
+			auto policies = parse_policies(maybe_policies, &error);
+			if (!policies)
+			{
+				logger->error("Invalid policies specified: {}", error);
+				exit(EXIT_FAILURE);
+			}
+			logger->info("Using {} policy rule(s)", policies->size());
+			cfg->policies = std::move(*policies);
+		}
 	}
 
 	if (absl::GetFlag(FLAGS_no_common_tags))

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -4,9 +4,16 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace spectator
 {
+
+struct PolicyRule
+{
+	std::map<std::string, std::string> match_tags;
+	std::vector<std::string> omit_common_tags;
+};
 
 class Config
 {
@@ -34,6 +41,7 @@ class Config
 	{
 	}
 	std::map<std::string, std::string> common_tags;
+	std::vector<PolicyRule> policies{{{{"nf.process", "spark-executor"}}, {"nf.node"}}};
 	absl::Duration read_timeout;
 	absl::Duration connect_timeout;
 	int batch_size{};

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -15,6 +15,7 @@
 #include <asio/post.hpp>
 #include <asio/thread_pool.hpp>
 #include <atomic>
+#include <algorithm>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
@@ -56,6 +57,10 @@ class Publisher
 		for (const auto& kv : registry_->GetConfig().common_tags)
 		{
 			common_tags_.add(kv.first, kv.second);
+		}
+		for (const auto& rule : registry_->GetConfig().policies)
+		{
+			policies_.emplace_back(rule);
 		}
 	}
 
@@ -141,6 +146,27 @@ class Publisher
 	std::shared_ptr<Counter> droppedHttp_;
 	std::shared_ptr<Counter> droppedOther_;
 	Tags common_tags_;
+
+	struct InternedPolicyRule
+	{
+		Tags match_tags;
+		std::vector<StrRef> omit_common_tags;
+
+		explicit InternedPolicyRule(const PolicyRule& rule)
+		{
+			for (const auto& kv : rule.match_tags)
+			{
+				match_tags.add(kv.first, kv.second);
+			}
+			omit_common_tags.reserve(rule.omit_common_tags.size());
+			for (const auto& tag : rule.omit_common_tags)
+			{
+				omit_common_tags.emplace_back(intern_str(tag));
+			}
+		}
+	};
+
+	std::vector<InternedPolicyRule> policies_;
 	size_t num_sender_threads_;
 	asio::thread_pool pool_;
 	std::vector<SmilePayload> buffers_;
@@ -223,6 +249,54 @@ class Publisher
 		Max = 10
 	};
 
+	static auto rule_matches(const InternedPolicyRule& rule, const Tags& tags) -> bool
+	{
+		for (const auto& matcher : rule.match_tags)
+		{
+			if (tags.at(matcher.key) != matcher.value)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static auto rule_omits_common_tag(const InternedPolicyRule& rule, StrRef key) -> bool
+	{
+		return std::find(rule.omit_common_tags.begin(), rule.omit_common_tags.end(), key) !=
+		       rule.omit_common_tags.end();
+	}
+
+	// Policies let the same daemon publish host-level Hadoop metrics and Spark
+	// executor metrics with different common-tag handling. For example, the
+	// default policy language rule `tag:nf.process=spark-executor->omit:nf.node`
+	// keeps node identity for system metrics while omitting nf.node for executor metrics.
+	auto should_omit_common_tag(const Measurement& measurement, StrRef key) const -> bool
+	{
+		const auto& tags = measurement.id.GetTags();
+		for (const auto& rule : policies_)
+		{
+			if (rule_omits_common_tag(rule, key) && rule_matches(rule, tags))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	auto common_tags_size_for_measurement(const Measurement& measurement) const -> size_t
+	{
+		size_t size = 0;
+		for (const auto& tag : common_tags_)
+		{
+			if (!should_omit_common_tag(measurement, tag.key))
+			{
+				++size;
+			}
+		}
+		return size;
+	}
+
 	auto op_from_tags(const Tags& tags) -> Op
 	{
 		auto stat = tags.at(refs().statistic());
@@ -239,26 +313,38 @@ class Publisher
 	{
 		for (const auto& tag : tags)
 		{
-			auto k_pair = strings.find(tag.key);
-			auto v_pair = strings.find(tag.value);
-			assert(k_pair != strings.end());
-			assert(v_pair != strings.end());
-			payload->Append(k_pair->second);
-			payload->Append(v_pair->second);
+			add_tag(payload, strings, tag);
 		}
 	}
 
-	void append_measurement(SmilePayload* payload, const StrTable& strings, const std::vector<int>& common_ids,
-	                        const Measurement& m)
+	void add_tag(SmilePayload* payload, const StrTable& strings, const Tag& tag)
+	{
+		auto k_pair = strings.find(tag.key);
+		auto v_pair = strings.find(tag.value);
+		assert(k_pair != strings.end());
+		assert(v_pair != strings.end());
+		payload->Append(k_pair->second);
+		payload->Append(v_pair->second);
+	}
+
+	void add_common_tags(SmilePayload* payload, const StrTable& strings, const Measurement& measurement)
+	{
+		for (const auto& tag : common_tags_)
+		{
+			if (!should_omit_common_tag(measurement, tag.key))
+			{
+				add_tag(payload, strings, tag);
+			}
+		}
+	}
+
+	void append_measurement(SmilePayload* payload, const StrTable& strings, const Measurement& m)
 	{
 		auto op = op_from_tags(m.id.GetTags());
-		auto common_tags_size = common_ids.size() / 2;
+		auto common_tags_size = common_tags_size_for_measurement(m);
 		auto total_tags = m.id.GetTags().size() + 1 + common_tags_size;
 		payload->Append(total_tags);
-		for (auto i : common_ids)
-		{
-			payload->Append(i);
-		}
+		add_common_tags(payload, strings, m);
 		add_tags(payload, strings, m.id.GetTags());
 		auto name_idx = strings.find(refs().name())->second;
 		auto name_value_idx = strings.find(m.id.Name())->second;
@@ -269,31 +355,14 @@ class Publisher
 		payload->Append(m.value);
 	}
 
-	auto get_common_ids(const StrTable& strings) -> std::vector<int>
-	{
-		std::vector<int> ids;
-		ids.reserve(common_tags_.size() * 2);
-		for (const auto& tag : common_tags_)
-		{
-			auto key_pair = strings.find(tag.key);
-			auto val_pair = strings.find(tag.value);
-			assert(key_pair != strings.end());
-			assert(val_pair != strings.end());
-			ids.emplace_back(key_pair->second);
-			ids.emplace_back(val_pair->second);
-		}
-		return ids;
-	}
-
 	void measurements_to_json(SmilePayload* payload, std::vector<Measurement>::const_iterator first,
 	                          std::vector<Measurement>::const_iterator last)
 	{
 		payload->Init();
 		auto strings = build_str_table(payload, first, last);
-		auto common_ids = get_common_ids(strings);
 		for (auto it = first; it != last; ++it)
 		{
-			append_measurement(payload, strings, common_ids, *it);
+			append_measurement(payload, strings, *it);
 		}
 	}
 

--- a/spectator/publisher_test.cc
+++ b/spectator/publisher_test.cc
@@ -1,0 +1,103 @@
+#include "publisher.h"
+#include "registry.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string_view>
+#include <utility>
+
+namespace
+{
+
+using spectator::GetConfiguration;
+using spectator::Id;
+using spectator::Measurement;
+using spectator::Registry;
+using spectator::Tags;
+
+class TestPublisher : public spectator::Publisher<Registry>
+{
+   public:
+	explicit TestPublisher(Registry* registry) : Publisher(registry) {}
+
+	auto CommonTagCount(const Measurement& measurement) const -> size_t
+	{
+		return common_tags_size_for_measurement(measurement);
+	}
+
+	auto OmitsCommonTag(const Measurement& measurement, std::string_view key) const -> bool
+	{
+		return should_omit_common_tag(measurement, spectator::intern_str(key));
+	}
+};
+
+auto new_registry() -> std::unique_ptr<Registry>
+{
+	auto config = GetConfiguration();
+	config->common_tags = {{"nf.app", "hadoop"}, {"nf.node", "i-123"}, {"nf.region", "us-east-1"}};
+	return std::make_unique<Registry>(std::move(config), spectatord::Logger());
+}
+
+TEST(PublisherMetricPolicy, KeepsNodeCommonTagForSystemMetrics)
+{
+	auto registry = new_registry();
+	TestPublisher publisher{registry.get()};
+	Id id{"node.cpu.usage", Tags{{"nf.process", "node-exporter"}}};
+	Measurement measurement{id, 1.0};
+
+	EXPECT_FALSE(publisher.OmitsCommonTag(measurement, "nf.node"));
+	EXPECT_EQ(publisher.CommonTagCount(measurement), 3);
+}
+
+TEST(PublisherMetricPolicy, OmitsNodeCommonTagWhenNfProcessIsSparkExecutor)
+{
+	auto registry = new_registry();
+	TestPublisher publisher{registry.get()};
+	Id id{"jvm.cpu.usage", Tags{{"nf.process", "spark-executor"}}};
+	Measurement measurement{id, 1.0};
+
+	EXPECT_TRUE(publisher.OmitsCommonTag(measurement, "nf.node"));
+	EXPECT_FALSE(publisher.OmitsCommonTag(measurement, "nf.app"));
+	EXPECT_EQ(publisher.CommonTagCount(measurement), 2);
+}
+
+TEST(PublisherMetricPolicy, KeepsNodeCommonTagForExecutorIdWithoutSparkExecutorProcess)
+{
+	auto registry = new_registry();
+	TestPublisher publisher{registry.get()};
+	Id id{"jvm.cpu.usage", Tags{{"executorId", "3"}}};
+	Measurement measurement{id, 1.0};
+
+	EXPECT_FALSE(publisher.OmitsCommonTag(measurement, "nf.node"));
+	EXPECT_EQ(publisher.CommonTagCount(measurement), 3);
+}
+
+TEST(PublisherMetricPolicy, KeepsNodeCommonTagForSparkExecutorNamedMetricsWithoutSparkExecutorProcess)
+{
+	auto registry = new_registry();
+	TestPublisher publisher{registry.get()};
+	Id id{"spark.executor.runTime", Tags{}};
+	Measurement measurement{id, 1.0};
+
+	EXPECT_FALSE(publisher.OmitsCommonTag(measurement, "nf.node"));
+	EXPECT_EQ(publisher.CommonTagCount(measurement), 3);
+}
+
+TEST(PublisherMetricPolicy, AppliesConfigurablePolicyRule)
+{
+	auto config = GetConfiguration();
+	config->common_tags = {{"nf.app", "hadoop"}, {"nf.node", "i-123"}, {"nf.region", "us-east-1"}};
+	config->policies = {{{{"source", "custom"}}, {"nf.region", "nf.node"}}};
+	Registry registry{std::move(config), spectatord::Logger()};
+	TestPublisher publisher{&registry};
+	Id id{"custom.metric", Tags{{"source", "custom"}}};
+	Measurement measurement{id, 1.0};
+
+	EXPECT_TRUE(publisher.OmitsCommonTag(measurement, "nf.node"));
+	EXPECT_TRUE(publisher.OmitsCommonTag(measurement, "nf.region"));
+	EXPECT_FALSE(publisher.OmitsCommonTag(measurement, "nf.app"));
+	EXPECT_EQ(publisher.CommonTagCount(measurement), 1);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- add configurable publishing policies for per-metric common-tag omission
- default policy omits `nf.node` when a metric has `nf.process=spark-executor`
- expose policies in `/config` and via `--policies` CLI override

## Example config

A Hadoop EC2 node can keep `nf.node` on host/system metrics while omitting it for Spark executor metrics by adding a policy like:

```yaml
policies:
  - match_tags:
      nf.process: spark-executor
    omit_common_tags:
      - nf.node
```

CLI override for local testing:

```bash
--policies='tag:nf.process=spark-executor->omit:nf.node'
```

## Testing
- `source venv/bin/activate && cmake --build cmake-build --target spectator_test spectatord_main spectatord_test`
- `cmake-build/bin/spectator_test --gtest_filter=PublisherMetricPolicy.*`
- `cmake-build/bin/spectatord_main --help | grep -A3 policies`
- `git diff --check`
