### PR TITLE
admin_server: Fix use after free in /metrics handler

### DIFF
--- a/admin/admin_server.cc
+++ b/admin/admin_server.cc
@@ -178,7 +178,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr age_gauges = new Poco::JSON::Array(true);
 	for (auto it : registry.AgeGauges())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Value()));
 		age_gauges->add(meter);
 	}
@@ -187,7 +187,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr counters = new Poco::JSON::Array(true);
 	for (auto it : registry.Counters())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Count()));
 		counters->add(meter);
 	}
@@ -196,7 +196,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr dist_summaries = new Poco::JSON::Array(true);
 	for (auto it : registry.DistSummaries())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->TotalAmount()));
 		dist_summaries->add(meter);
 	}
@@ -205,7 +205,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr gauges = new Poco::JSON::Array(true);
 	for (auto it : registry.Gauges())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Get()));
 		gauges->add(meter);
 	}
@@ -214,7 +214,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr max_gauges = new Poco::JSON::Array(true);
 	for (auto it : registry.MaxGauges())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Get()));
 		max_gauges->add(meter);
 	}
@@ -223,7 +223,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr mono_counters = new Poco::JSON::Array(true);
 	for (auto it : registry.MonotonicCounters())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Delta()));
 		mono_counters->add(meter);
 	}
@@ -232,7 +232,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr mono_counters_uint = new Poco::JSON::Array(true);
 	for (auto it : registry.MonotonicCountersUint())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->Delta()));
 		mono_counters_uint->add(meter);
 	}
@@ -241,7 +241,7 @@ void GET_metrics(HTTPServerRequest& req, HTTPServerResponse& res, spectator::Reg
 	Poco::JSON::Array::Ptr timers = new Poco::JSON::Array(true);
 	for (auto it : registry.Timers())
 	{
-		auto meter = fmt_meter_object((spectator::Meter*)it);
+		auto meter = fmt_meter_object((spectator::Meter*)it.get());
 		meter->set("value", fmt::format("{}", it->TotalTime()));
 		timers->add(meter);
 	}

--- a/spectator/http/http_client_test.cc
+++ b/spectator/http/http_client_test.cc
@@ -39,7 +39,7 @@ const Timer* find_timer(Registry* registry, const std::string& name, const std::
 			auto t = m->MeterId().GetTags().at(intern_str("http.status"));
 			if (t == status_code_ref)
 			{
-				return m;
+				return m.get();
 			}
 		}
 	}

--- a/spectator/registry/registry.h
+++ b/spectator/registry/registry.h
@@ -162,15 +162,15 @@ struct meter_map
 		return res;
 	}
 
-	auto get_values() const -> std::vector<const M*>
+	auto get_values() const -> std::vector<std::shared_ptr<const M>>
 	{
-		std::vector<const M*> res;
+		std::vector<std::shared_ptr<const M>> res;
 		{
 			absl::MutexLock lock{&meters_mutex_};
 			res.reserve(meters_.size());
 			for (const auto& pair : meters_)
 			{
-				res.emplace_back(pair.second.get());
+				res.emplace_back(pair.second);
 			}
 		}
 		return res;
@@ -329,23 +329,29 @@ class Registry
 	void DeleteAllMeters(const std::string& type);
 
 	// for debugging / testing
-	auto AgeGauges() const -> std::vector<const AgeGauge*> { return all_meters_.age_gauges_.get_values(); }
-	auto Counters() const -> std::vector<const Counter*> { return all_meters_.counters_.get_values(); }
-	auto DistSummaries() const -> std::vector<const DistributionSummary*>
+	auto AgeGauges() const -> std::vector<std::shared_ptr<const AgeGauge>>
+	{
+		return all_meters_.age_gauges_.get_values();
+	}
+	auto Counters() const -> std::vector<std::shared_ptr<const Counter>> { return all_meters_.counters_.get_values(); }
+	auto DistSummaries() const -> std::vector<std::shared_ptr<const DistributionSummary>>
 	{
 		return all_meters_.dist_sums_.get_values();
 	}
-	auto Gauges() const -> std::vector<const Gauge*> { return all_meters_.gauges_.get_values(); }
-	auto MaxGauges() const -> std::vector<const MaxGauge*> { return all_meters_.max_gauges_.get_values(); }
-	auto MonotonicCounters() const -> std::vector<const MonotonicCounter*>
+	auto Gauges() const -> std::vector<std::shared_ptr<const Gauge>> { return all_meters_.gauges_.get_values(); }
+	auto MaxGauges() const -> std::vector<std::shared_ptr<const MaxGauge>>
+	{
+		return all_meters_.max_gauges_.get_values();
+	}
+	auto MonotonicCounters() const -> std::vector<std::shared_ptr<const MonotonicCounter>>
 	{
 		return all_meters_.mono_counters_.get_values();
 	}
-	auto MonotonicCountersUint() const -> std::vector<const MonotonicCounterUint*>
+	auto MonotonicCountersUint() const -> std::vector<std::shared_ptr<const MonotonicCounterUint>>
 	{
 		return all_meters_.mono_counters_uint_.get_values();
 	}
-	auto Timers() const -> std::vector<const Timer*> { return all_meters_.timers_.get_values(); }
+	auto Timers() const -> std::vector<std::shared_ptr<const Timer>> { return all_meters_.timers_.get_values(); }
 	auto GetLastSuccessTime() const -> int64_t { return publisher_.GetLastSuccessTime(); }
 
    private:

--- a/spectator/registry/registry_test.cc
+++ b/spectator/registry/registry_test.cc
@@ -237,4 +237,26 @@ TEST(Registry, DeleteMeters)
 	EXPECT_DOUBLE_EQ(r.AgeGauges().size(), 0.0);
 }
 
+TEST(Registry, MeterSnapshotOutlivesExpiry)
+{
+	Registry r{GetConfiguration(), spectatord::Logger()};
+	r.GetGauge("g1")->Set(1.0);
+	r.GetGauge("g2")->Set(1.0);
+
+	// simulate admin thread capturing snapshot during GET /metrics
+	auto snapshot = r.Gauges();
+	ASSERT_FALSE(snapshot.empty());
+
+	// simulate expiring all the gauges out of the registry
+	r.DeleteAllMeters("g");
+	ASSERT_TRUE(r.Gauges().empty());
+
+	// simulate admin thread using snapshot to respond to GET after expiry
+	ASSERT_FALSE(snapshot.empty());
+	for (const auto& g : snapshot)
+	{
+		EXPECT_NE(g->MeterId().Name().Get(), nullptr);
+	}
+}
+
 }  // namespace

--- a/spectator/registry/test_utils.h
+++ b/spectator/registry/test_utils.h
@@ -8,11 +8,11 @@
 auto measurements_to_map(const std::vector<spectator::Measurement>& measurements) -> std::map<std::string, double>;
 
 template <typename T>
-auto filter_my_meters(const std::vector<const T*> source) -> std::vector<const T*>
+auto filter_my_meters(const std::vector<std::shared_ptr<const T>> source) -> std::vector<std::shared_ptr<const T>>
 {
-	std::vector<const T*> result;
+	std::vector<std::shared_ptr<const T>> result;
 	std::copy_if(source.begin(), source.end(), std::back_inserter(result),
-	             [](const T* t)
+	             [](const std::shared_ptr<const T>& t)
 	             {
 		             std::string name = t->MeterId().Name().Get();
 		             auto found = name.rfind("spectator.", 0);
@@ -21,38 +21,42 @@ auto filter_my_meters(const std::vector<const T*> source) -> std::vector<const T
 	return result;
 }
 
-inline auto my_timers(const spectator::Registry& registry) -> std::vector<const spectator::Timer*>
+inline auto my_timers(const spectator::Registry& registry) -> std::vector<std::shared_ptr<const spectator::Timer>>
 {
 	using spectator::Timer;
 	return filter_my_meters(registry.Timers());
 }
 
-inline auto my_counters(const spectator::Registry& registry) -> std::vector<const spectator::Counter*>
+inline auto my_counters(const spectator::Registry& registry) -> std::vector<std::shared_ptr<const spectator::Counter>>
 {
 	return filter_my_meters(registry.Counters());
 }
 
-inline auto my_ds(const spectator::Registry& registry) -> std::vector<const spectator::DistributionSummary*>
+inline auto my_ds(const spectator::Registry& registry)
+    -> std::vector<std::shared_ptr<const spectator::DistributionSummary>>
 {
 	return filter_my_meters(registry.DistSummaries());
 }
 
-inline auto my_gauges(const spectator::Registry& registry) -> std::vector<const spectator::Gauge*>
+inline auto my_gauges(const spectator::Registry& registry) -> std::vector<std::shared_ptr<const spectator::Gauge>>
 {
 	return filter_my_meters(registry.Gauges());
 }
 
-inline auto my_age_gauges(const spectator::Registry& registry) -> std::vector<const spectator::AgeGauge*>
+inline auto my_age_gauges(const spectator::Registry& registry)
+    -> std::vector<std::shared_ptr<const spectator::AgeGauge>>
 {
 	return filter_my_meters(registry.AgeGauges());
 }
 
-inline auto my_max_gauges(const spectator::Registry& registry) -> std::vector<const spectator::MaxGauge*>
+inline auto my_max_gauges(const spectator::Registry& registry)
+    -> std::vector<std::shared_ptr<const spectator::MaxGauge>>
 {
 	return filter_my_meters(registry.MaxGauges());
 }
 
-inline auto my_mono_counters(const spectator::Registry& registry) -> std::vector<const spectator::MonotonicCounter*>
+inline auto my_mono_counters(const spectator::Registry& registry)
+    -> std::vector<std::shared_ptr<const spectator::MonotonicCounter>>
 {
 	return filter_my_meters(registry.MonotonicCounters());
 }


### PR DESCRIPTION
commit d1fbb49332bc82c820bfa3c329c5e02538a1a7e9
Author:     Andrew Halaney <ahalaney@netflix.com>
AuthorDate: Mon Jun 8 10:43:01 2026 -0500
Commit:     Andrew Halaney <ahalaney@netflix.com>
CommitDate: Mon Jun 8 11:22:44 2026 -0500

    registry_test: simulate admin thread's /metrics GET during expiration

    This simulates the admin thread using its snapshot of all meters to
    formulate a response while those meters are being expired.

    In reality this happens in parallel, but for simplicity do this
    simluation sequentially to force the situation.

commit 4251f2d336dc23de242d99c876c7f4ab2da4bb4d
Author:     Andrew Halaney <ahalaney@netflix.com>
AuthorDate: Mon Jun 8 09:45:03 2026 -0500
Commit:     Andrew Halaney <ahalaney@netflix.com>
CommitDate: Mon Jun 8 11:22:38 2026 -0500

    admin_server: Fix use after free in /metrics handler

    The GET /metrics admin endpoint iterates over meter snapshots, and in
    parallel the janitorial expiration thread can remove these meters from
    the registry. This means by the time we access the meter via its raw
    pointer in the admin thread it could be free'd, as is the case with this
    backtrace it seems:

        # Calling application using admin server interface
        "(...)"NvmeExceededUsageProblem check failed: disk nvme metrics: error querying spectator metrics: Get \\\"http://localhost:1234/metrics\\\": EOF\"}](...)"

        # spectatord.service
        "Segmentation fault (Address not mapped to object [(nil)])",
        "#0    Object \"/usr/lib/x86_64-linux-gnu/libc.so.6\", at 0x7fcb4a7bb93c, in",
        "#1    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a74ee28, in void fmt::v11::detail::value<fmt::v11::context>::format_custom_arg<spectator::StrRef, fmt::v11::formatter<spectator::StrRef, char, void> >(void*, fmt::v11::basic_format_parse_context<char>&, fmt::v11::context&)",
        "#2    Object \"/apps/spectatord/bin/spectatord\", at 0x56055ae96482, in void fmt::v11::detail::vformat_to<char>(fmt::v11::detail::buffer<char>&, fmt::v11::basic_string_view<char>, fmt::v11::detail::vformat_args<char>::type, fmt::v11::detail::locale_ref)",
        "#3    Object \"/apps/spectatord/bin/spectatord\", at 0x56055ae8471f, in fmt::v11::vformat[abi:cxx11](fmt::v11::basic_string_view<char>, fmt::v11::basic_format_args<fmt::v11::context>)",
        "#4    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a763827, in admin::fmt_meter_object(spectator::Meter*)",
        "#5    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a764d95, in admin::GET_metrics(Poco::Net::HTTPServerRequest&, Poco::Net::HTTPServerResponse&, spectator::Registry&)",
        "#6    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a7f2b30, in Poco::Net::HTTPServerConnection::run()",
        "#7    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a7fa3b6, in Poco::Net::TCPServerConnection::start()",
        "#8    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a7ee76f, in Poco::Net::TCPServerDispatcher::run()",
        "#9    Object \"/apps/spectatord/bin/spectatord\", at 0x56055a854c55, in Poco::PooledThread::run()",
        "#10   Object \"/apps/spectatord/bin/spectatord\", at 0x56055a8521ea, in Poco::ThreadImpl::runnableEntry(void*)",
        "#11   Object \"/usr/lib/x86_64-linux-gnu/libc.so.6\", at 0x7fcb4a698b06, in",
        "#12   Object \"/usr/lib/x86_64-linux-gnu/libc.so.6\", at 0x7fcb4a72e58f, in",
        "#13   Object \"\", at 0xffffffffffffffff, in",
        "Stack trace (most recent call last) in thread 4417:",

    Let's change things to use a shared_ptr in this admin thread context too
    to avoid the meter being freed while still in use.
