### PR TITLE
Add distinct count sketch type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(spectator_test
     "spectator/meters/perc_buckets_test.cc"
     "spectator/meters/tags_test.cc"
     "spectator/meters/timer_test.cc"
+    "spectator/registry/distinct_count_sketch_test.cc"
     "spectator/registry/perc_dist_summary_test.cc"
     "spectator/registry/perc_timer_test.cc"
     "spectator/registry/registry_test.cc"

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -4,6 +4,7 @@
 #include "server/transport/udp_server.h"
 #include "util/systemd.h"
 
+#include <absl/strings/escaping.h>
 #include <asio.hpp>
 
 namespace spectatord
@@ -303,35 +304,55 @@ auto get_measurement(char type, std::string_view measurement_str, std::string* e
 
 	++pos;
 	auto value_str = measurement_str.begin() + pos;
-	char* last_char = nullptr;
 	valueT value{};
-	if (type == 'U')
+	std::string_view str_value{};
+	if (type == 'S')
 	{
-		value.u = std::strtoull(value_str, &last_char, 10);
+		// The distinct count sketch value is an opaque base64 blob (the bytes to hash), not a
+		// number. Capture the raw token; it is decoded and hashed in parse_line. Treat it like a
+		// tag value with respect to size: it is bounded by the overall line size limits.
+		str_value = measurement_str.substr(pos);
+		while (!str_value.empty() && std::isspace(static_cast<unsigned char>(str_value.back())) != 0)
+		{
+			str_value.remove_suffix(1);
+		}
+		if (str_value.empty())
+		{
+			*err_msg = "Unable to parse value for measurement";
+			return {};
+		}
 	}
 	else
 	{
-		value.d = std::strtod(value_str, &last_char);
-	}
-
-	if (last_char == value_str)
-	{
-		*err_msg = "Unable to parse value for measurement";
-		return {};
-	}
-	if (*last_char != '\0' && std::isspace(*last_char) == 0)
-	{
-		if (type == 'U')
+		char* last_char = nullptr;
+		if (type == 'U' || type == 's')
 		{
-			*err_msg = fmt::format("Got {} parsing value, ignoring chars starting at {}", value.u, last_char);
+			value.u = std::strtoull(value_str, &last_char, 10);
 		}
 		else
 		{
-			*err_msg = fmt::format("Got {} parsing value, ignoring chars starting at {}", value.d, last_char);
+			value.d = std::strtod(value_str, &last_char);
+		}
+
+		if (last_char == value_str)
+		{
+			*err_msg = "Unable to parse value for measurement";
+			return {};
+		}
+		if (*last_char != '\0' && std::isspace(static_cast<unsigned char>(*last_char)) == 0)
+		{
+			if (type == 'U' || type == 's')
+			{
+				*err_msg = fmt::format("Got {} parsing value, ignoring chars starting at {}", value.u, last_char);
+			}
+			else
+			{
+				*err_msg = fmt::format("Got {} parsing value, ignoring chars starting at {}", value.d, last_char);
+			}
 		}
 	}
 	auto name_ref = spectator::intern_str(name);
-	return measurement{spectator::Id{name_ref, tags}, value};
+	return measurement{spectator::Id{name_ref, tags}, value, str_value};
 }
 
 static constexpr auto min_perc_timer = absl::Nanoseconds(1);
@@ -349,6 +370,11 @@ static auto create_perc_ds(spectator::Registry* registry, spectator::Id id)
 	return std::make_unique<spectator::PercentileDistributionSummary>(registry, std::move(id), min_ds, max_ds);
 }
 
+static auto create_sketch(spectator::Registry* registry, spectator::Id id)
+{
+	return std::make_unique<spectator::DistinctCountSketch>(registry, std::move(id));
+}
+
 Server::Server(bool ipv4_only, int port_number, std::optional<int> statsd_port_number,
                std::optional<std::string> socket_path, spectator::Registry* registry)
     : ipv4_only_{ipv4_only},
@@ -360,7 +386,8 @@ Server::Server(bool ipv4_only, int port_number, std::optional<int> statsd_port_n
       parse_errors_{registry_->GetCounter("spectatord.parseErrors")},
       logger_{Logger()},
       perc_timers_{create_perc_timer},
-      perc_ds_{create_perc_ds}
+      perc_ds_{create_perc_ds},
+      sketches_{create_sketch}
 {
 }
 
@@ -505,6 +532,10 @@ void Server::upkeep()
 	    registry_->GetCounter("spectatord.percentileExpired", spectator::Tags{{"id", "timer"}});
 	static auto ds_expired_ctr =
 	    registry_->GetCounter("spectatord.percentileExpired", spectator::Tags{{"id", "dist-summary"}});
+	static auto sketch_size_gauge =
+	    registry_->GetGauge("spectatord.sketchCacheSize", spectator::Tags{{"id", "distinct"}});
+	static auto sketch_expired_ctr =
+	    registry_->GetCounter("spectatord.sketchExpired", spectator::Tags{{"id", "distinct"}});
 
 	static auto pool_hits = registry_->GetMonotonicCounter("spectatord.poolAccess", spectator::Tags{{"id", "hit"}});
 	static auto pool_misses = registry_->GetMonotonicCounter("spectatord.poolAccess", spectator::Tags{{"id", "miss"}});
@@ -520,18 +551,23 @@ void Server::upkeep()
 	size_t ds_expired = 0;
 	size_t t_size = 0;
 	size_t t_expired = 0;
+	size_t sketch_size = 0;
+	size_t sketch_expired = 0;
 	while (!should_stop_)
 	{
 		auto start = clock::now();
 
 		std::tie(ds_size, ds_expired) = perc_ds_.expire();
 		std::tie(t_size, t_expired) = perc_timers_.expire();
+		std::tie(sketch_size, sketch_expired) = sketches_.expire();
 		if (cfg.status_metrics_enabled)
 		{
 			timers_size_gauge->Set(t_size);
 			ds_size_gauge->Set(ds_size);
 			timers_expired_ctr->Add(t_expired);
 			ds_expired_ctr->Add(ds_expired);
+			sketch_size_gauge->Set(sketch_size);
+			sketch_expired_ctr->Add(sketch_expired);
 		}
 #ifdef __linux__
 		update_network_metrics();
@@ -685,6 +721,23 @@ auto Server::parse_line(const char* buffer) -> std::optional<std::string>
 			break;
 		case 'm':
 			registry_->GetMaxGauge(measurement->id)->Update(measurement->value.d);
+			break;
+		case 'S':
+		{
+			// Distinct count sketch: the value is base64-encoded raw bytes that spectatord
+			// hashes. This keeps the hash implementation in one place for all thin clients.
+			std::string decoded;
+			if (!absl::Base64Unescape(measurement->str_value, &decoded))
+			{
+				return fmt::format("Invalid base64 value for distinct count sketch: {}", measurement->str_value);
+			}
+			sketches_.get_or_create(registry_, measurement->id)->Record(decoded.data(), decoded.size());
+		}
+		break;
+		case 's':
+			// Distinct count sketch with a precomputed xxHash64 (seed 0) value, for clients that
+			// hash locally (e.g. to keep the raw value off the wire or bound the line size).
+			sketches_.get_or_create(registry_, measurement->id)->RecordHash(measurement->value.u);
 			break;
 		case 't':  // elapsed time is reported in seconds
 		{

--- a/server/spectatord.cc
+++ b/server/spectatord.cc
@@ -311,15 +311,14 @@ auto get_measurement(char type, std::string_view measurement_str, std::string* e
 		// The distinct count sketch value is an opaque base64 blob (the bytes to hash), not a
 		// number. Capture the raw token; it is decoded and hashed in parse_line. Treat it like a
 		// tag value with respect to size: it is bounded by the overall line size limits.
+		//
+		// An empty value is allowed: it decodes to zero bytes and hashes the empty input, which
+		// matches record("") / record(empty bytes) in the other clients so the sketches merge.
+		// A genuinely missing value (no trailing ':') is rejected earlier as a missing name.
 		str_value = measurement_str.substr(pos);
 		while (!str_value.empty() && std::isspace(static_cast<unsigned char>(str_value.back())) != 0)
 		{
 			str_value.remove_suffix(1);
-		}
-		if (str_value.empty())
-		{
-			*err_msg = "Unable to parse value for measurement";
-			return {};
 		}
 	}
 	else

--- a/server/spectatord.h
+++ b/server/spectatord.h
@@ -2,6 +2,7 @@
 
 #include "expiring_cache.h"
 #include "server/transport/handler.h"
+#include "spectator/registry/distinct_count_sketch.h"
 #include "spectator/registry/percentile_distribution_summary.h"
 #include "spectator/registry/percentile_timer.h"
 #include "spectator/registry/registry.h"
@@ -35,6 +36,7 @@ class Server
 	std::shared_ptr<spdlog::logger> logger_;
 	expiring_cache<spectator::PercentileTimer> perc_timers_;
 	expiring_cache<spectator::PercentileDistributionSummary> perc_ds_;
+	expiring_cache<spectator::DistinctCountSketch> sketches_;
 
 	std::atomic_bool should_stop_{false};
 	std::thread upkeep_thread_;  // some janitorial tasks, like expiration of
@@ -64,6 +66,9 @@ struct measurement
 {
 	spectator::Id id;
 	valueT value;
+	// Raw (un-parsed) value token, used by the distinct count sketch 'S' type whose value is a
+	// base64 blob to hash rather than a number. Points into the parse buffer.
+	std::string_view str_value{};
 };
 
 std::optional<measurement> get_measurement(char type, std::string_view measurement_str, std::string* err_msg);

--- a/server/spectatord_test.cc
+++ b/server/spectatord_test.cc
@@ -480,4 +480,45 @@ TEST(Spectatord, ParseTimer)
 	EXPECT_DOUBLE_EQ(map["timer.name|statistic=totalTime"], 0.002);
 	EXPECT_DOUBLE_EQ(map["timer.name|statistic=max"], 0.001);
 }
+
+// The value "a" hashes (xxHash64, seed 0) to register index 27 (R1B) with rho 1, per the
+// shared cross-language test vectors. base64("a") == "YQ==".
+TEST(Spectatord, ParseDistinctSketchBase64)
+{
+	auto logger = Logger();
+	spectator::Registry registry{GetConfiguration(), logger};
+	test_server server{&registry};
+
+	char_ptr line{strdup("S:dcs.name:YQ==")};
+	EXPECT_FALSE(server.parse_msg(line.get()).has_value());
+
+	auto map = server.measurements();
+	EXPECT_DOUBLE_EQ(map["spectatord.parsedCount|statistic=count"], 1);
+	EXPECT_DOUBLE_EQ(map["dcs.name|distinct=R1B|statistic=distinct"], 1);
+}
+
+// The precomputed-hash variant must land in the same register as the base64 variant.
+TEST(Spectatord, ParseDistinctSketchPrecomputedHash)
+{
+	auto logger = Logger();
+	spectator::Registry registry{GetConfiguration(), logger};
+	test_server server{&registry};
+
+	char_ptr line{strdup("s:dcs.name:15154266338359012955")};
+	EXPECT_FALSE(server.parse_msg(line.get()).has_value());
+
+	auto map = server.measurements();
+	EXPECT_DOUBLE_EQ(map["dcs.name|distinct=R1B|statistic=distinct"], 1);
+}
+
+TEST(Spectatord, ParseDistinctSketchInvalidBase64)
+{
+	auto logger = Logger();
+	spectator::Registry registry{GetConfiguration(), logger};
+	test_server server{&registry};
+
+	char_ptr line{strdup("S:dcs.name:not valid base64!")};
+	auto err = server.parse_msg(line.get());
+	EXPECT_TRUE(err.has_value());
+}
 }  // namespace

--- a/server/spectatord_test.cc
+++ b/server/spectatord_test.cc
@@ -521,4 +521,20 @@ TEST(Spectatord, ParseDistinctSketchInvalidBase64)
 	auto err = server.parse_msg(line.get());
 	EXPECT_TRUE(err.has_value());
 }
+
+// An empty value (base64 of zero bytes) is valid: it hashes the empty byte sequence, which the
+// shared vectors map to register R19 (index 25) with rho 1, matching record("") in the other
+// clients so sketches merge.
+TEST(Spectatord, ParseDistinctSketchEmptyValue)
+{
+	auto logger = Logger();
+	spectator::Registry registry{GetConfiguration(), logger};
+	test_server server{&registry};
+
+	char_ptr line{strdup("S:dcs.name:")};
+	EXPECT_FALSE(server.parse_msg(line.get()).has_value());
+
+	auto map = server.measurements();
+	EXPECT_DOUBLE_EQ(map["dcs.name|distinct=R19|statistic=distinct"], 1);
+}
 }  // namespace

--- a/spectator/meters/max_gauge.cc
+++ b/spectator/meters/max_gauge.cc
@@ -19,7 +19,11 @@ void MaxGauge::Measure(Measurements* results) const noexcept
 	}
 	if (!max_id_)
 	{
-		max_id_ = std::make_unique<Id>(MeterId().WithStat(refs().max()));
+		// Preserve an existing statistic tag (e.g. statistic=distinct for the registers of a
+		// distinct count sketch); only default it to max when none is set. This matches the
+		// way Counter uses WithDefaultStat and keeps the published statistic correct for
+		// callers that decompose a metric into max gauges with their own statistic.
+		max_id_ = std::make_unique<Id>(MeterId().WithDefaultStat(refs().max()));
 	}
 	results->emplace_back(*max_id_, value);
 }

--- a/spectator/meters/max_gauge_test.cc
+++ b/spectator/meters/max_gauge_test.cc
@@ -79,6 +79,22 @@ TEST(MaxGauge, Measure)
 	EXPECT_EQ(expected, ms);
 }
 
+TEST(MaxGauge, PreservesExistingStatistic)
+{
+	// A max gauge whose id already carries a statistic (e.g. the per-register gauges of a
+	// distinct count sketch use statistic=distinct) must keep that statistic when measured,
+	// rather than have it overwritten with statistic=max. This matches Counter's behavior and
+	// is what lets DistinctCountSketch publish its registers as statistic=distinct.
+	auto id = spectator::Id("dcs", spectator::Tags{}).WithStat(refs().distinct());
+	spectator::MaxGauge g{id};
+	g.Update(3);
+
+	spectator::Measurements ms;
+	g.Measure(&ms);
+	ASSERT_EQ(ms.size(), 1);
+	EXPECT_EQ(ms.front().id, id);
+}
+
 TEST(MaxGauge, Updated)
 {
 	auto m = getMaxGauge("m");

--- a/spectator/registry/distinct_count_sketch.h
+++ b/spectator/registry/distinct_count_sketch.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "spectator/meters/id.h"
+#include "spectator/meters/max_gauge.h"
+#include "spectator/strings/common_refs.h"
+#include "spectator/strings/string_intern.h"
+#include "registry.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <string_view>
+
+#include "xxhash.h"
+
+namespace spectator
+{
+
+// Estimates the number of distinct values seen during a step interval using a HyperLogLog
+// sketch decomposed into a fixed set of per-register max gauges, tagged statistic=distinct
+// and distinct=R##. The registers merge across sources by taking the per-register max, and
+// the cardinality estimate is computed at query time on the backend.
+//
+// The hash and register encoding must match the spectator-java reference implementation
+// exactly so that sketches published by different clients merge correctly. This is verified
+// against a shared set of test vectors (see distinct_count_sketch_test.cc).
+class DistinctCountSketch
+{
+   public:
+	// Number of HLL registers. Fixed global constant: a distinct=R## tag must mean the same
+	// partition of the hash space everywhere or sketches from different sources cannot merge.
+	static constexpr int kRegisters = 64;
+
+	// Number of low bits of the hash used to select the register (log2(kRegisters)).
+	static constexpr int kIndexBits = 6;
+
+	// Mask to extract the register index from the low bits of the hash.
+	static constexpr uint64_t kIndexMask = kRegisters - 1;
+
+	// Maximum rho, produced when every bit beyond the index is zero (1 + 64 - kIndexBits).
+	static constexpr int kMaxRho = 64 - kIndexBits + 1;
+
+	// The register tags are formatted as "R%02X"; two hex digits only fit indices < 256.
+	static_assert(kRegisters <= 256, "register tag format R%02X assumes the index fits in two hex digits");
+
+	DistinctCountSketch(Registry* registry, Id id) noexcept : registry_{registry}, id_{std::move(id)} {}
+
+	// Record a distinct long value. Hashed as its 8-byte little-endian representation, matching
+	// the spectator-java record(long) overload.
+	void Record(int64_t value) noexcept
+	{
+		std::array<uint8_t, 8> bytes{};
+		auto v = static_cast<uint64_t>(value);
+		for (int i = 0; i < 8; ++i)
+		{
+			bytes[i] = static_cast<uint8_t>(v >> (8 * i));
+		}
+		RecordHash(XXH64(bytes.data(), bytes.size(), 0));
+	}
+
+	// Record a distinct string value, hashed as its UTF-8 bytes.
+	void Record(std::string_view value) noexcept { RecordHash(XXH64(value.data(), value.size(), 0)); }
+
+	// Record a distinct value from its raw bytes.
+	void Record(const void* data, size_t len) noexcept { RecordHash(XXH64(data, len, 0)); }
+
+	// Record a value from its precomputed xxHash64 (seed 0). Used by the precomputed-hash path
+	// where the caller has already hashed the value.
+	void RecordHash(uint64_t hash) noexcept { get_register(register_index(hash))->Update(register_rho(hash)); }
+
+	// Register index for a hash: the low kIndexBits bits.
+	static auto register_index(uint64_t hash) noexcept -> int { return static_cast<int>(hash & kIndexMask); }
+
+	// Register value (rho) for a hash: 1 + the number of leading zeros in the bits above the
+	// index. When every bit above the index is zero the result is kMaxRho.
+	static auto register_rho(uint64_t hash) noexcept -> int
+	{
+		uint64_t w = hash >> kIndexBits;
+		if (w == 0)
+		{
+			return kMaxRho;
+		}
+		// The top kIndexBits bits of w are zero, so subtract them back out of the count.
+		return __builtin_clzll(w) - kIndexBits + 1;
+	}
+
+	auto MeterId() const noexcept -> const Id& { return id_; }
+
+   private:
+	Registry* registry_;
+	Id id_;
+
+	// Interned register tag values R00..R3F, matching the spectator-java String.format("R%02X").
+	static auto register_tags() -> const std::array<StrRef, kRegisters>&
+	{
+		static const std::array<StrRef, kRegisters> tags = [] {
+			std::array<StrRef, kRegisters> t{};
+			for (int i = 0; i < kRegisters; ++i)
+			{
+				char buf[4];
+				std::snprintf(buf, sizeof(buf), "R%02X", i);
+				t[i] = intern_str(buf);
+			}
+			return t;
+		}();
+		return tags;
+	}
+
+	auto get_register(int index) -> std::shared_ptr<MaxGauge>
+	{
+		auto reg_id = id_.WithTags(refs().statistic(), refs().distinct(), refs().distinct(), register_tags()[index]);
+		return registry_->GetMaxGauge(std::move(reg_id));
+	}
+};
+
+}  // namespace spectator

--- a/spectator/registry/distinct_count_sketch_test.cc
+++ b/spectator/registry/distinct_count_sketch_test.cc
@@ -1,0 +1,296 @@
+#include <gtest/gtest.h>
+#include "distinct_count_sketch.h"
+#include "test_utils.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "xxhash.h"
+
+// Verifies the DistinctCountSketch hashing and register encoding against a committed set of
+// cross-language test vectors generated from the spectator-java reference implementation.
+// The same file lives in both repositories; if it is regenerated there it must be copied
+// here. Any mismatch is a compatibility break that would prevent sketches published by
+// different clients from merging correctly.
+namespace
+{
+using namespace spectator;
+
+constexpr int kRegisters = DistinctCountSketch::kRegisters;
+constexpr const char* kVectorFile = "test-resources/distinct_count_sketch_test_vectors.txt";
+
+enum class Type
+{
+	Long,
+	Str,
+	Bytes
+};
+
+struct Input
+{
+	Type type;
+	int64_t long_value;
+	std::string bytes;  // UTF-8 bytes for Str, raw bytes for Bytes
+};
+
+// Compute the xxHash64 (seed 0) the same way the sketch does for each input type. This is an
+// independent check that the C++ hashing matches the hash column produced by spectator-java.
+auto hash_of(const Input& in) -> uint64_t
+{
+	if (in.type == Type::Long)
+	{
+		std::array<uint8_t, 8> b{};
+		auto v = static_cast<uint64_t>(in.long_value);
+		for (int i = 0; i < 8; ++i)
+		{
+			b[i] = static_cast<uint8_t>(v >> (8 * i));
+		}
+		return XXH64(b.data(), b.size(), 0);
+	}
+	return XXH64(in.bytes.data(), in.bytes.size(), 0);
+}
+
+void record_into(DistinctCountSketch* sketch, const Input& in)
+{
+	switch (in.type)
+	{
+		case Type::Long:
+			sketch->Record(in.long_value);
+			break;
+		case Type::Str:
+			sketch->Record(std::string_view{in.bytes});
+			break;
+		case Type::Bytes:
+			sketch->Record(in.bytes.data(), in.bytes.size());
+			break;
+	}
+}
+
+auto unescape(const std::string& s) -> std::string
+{
+	std::string out;
+	for (size_t i = 0; i < s.size(); ++i)
+	{
+		char c = s[i];
+		if (c == '\\' && i + 1 < s.size())
+		{
+			char n = s[++i];
+			switch (n)
+			{
+				case '\\': out += '\\'; break;
+				case 't': out += '\t'; break;
+				case 'n': out += '\n'; break;
+				case 'r': out += '\r'; break;
+				default: out += n; break;
+			}
+		}
+		else
+		{
+			out += c;
+		}
+	}
+	return out;
+}
+
+auto from_hex(const std::string& hex) -> std::string
+{
+	auto nibble = [](char c) -> int {
+		if (c >= '0' && c <= '9') return c - '0';
+		if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+		if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+		throw std::invalid_argument("invalid hex digit");
+	};
+	std::string out;
+	out.reserve(hex.size() / 2);
+	for (size_t i = 0; i + 1 < hex.size(); i += 2)
+	{
+		out += static_cast<char>((nibble(hex[i]) << 4) | nibble(hex[i + 1]));
+	}
+	return out;
+}
+
+auto decode_input(const std::string& type, const std::string& value) -> Input
+{
+	if (type == "long") return Input{Type::Long, std::stoll(value), {}};
+	if (type == "str") return Input{Type::Str, 0, unescape(value)};
+	if (type == "bytes") return Input{Type::Bytes, 0, from_hex(value)};
+	throw std::invalid_argument("unknown type: " + type);
+}
+
+// Split keeping empty fields (an empty string/bytes value is an empty field).
+auto split(const std::string& s, char delim) -> std::vector<std::string>
+{
+	std::vector<std::string> out;
+	size_t start = 0;
+	while (true)
+	{
+		auto pos = s.find(delim, start);
+		if (pos == std::string::npos)
+		{
+			out.push_back(s.substr(start));
+			break;
+		}
+		out.push_back(s.substr(start, pos - start));
+		start = pos + 1;
+	}
+	return out;
+}
+
+auto read_lines(const char* path) -> std::vector<std::string>
+{
+	std::ifstream in{path};
+	EXPECT_TRUE(in.is_open()) << "missing vector file: " << path;
+	std::vector<std::string> lines;
+	std::string line;
+	while (std::getline(in, line))
+	{
+		if (!line.empty() && line.back() == '\r')
+		{
+			line.pop_back();  // tolerate CRLF
+		}
+		lines.push_back(line);
+	}
+	return lines;
+}
+
+// Read the current value (max rho) of each register, mapping the unset NaN to 0.
+auto read_registers(Registry* r, const Id& id) -> std::array<int, kRegisters>
+{
+	std::array<int, kRegisters> regs{};
+	for (int i = 0; i < kRegisters; ++i)
+	{
+		char buf[4];
+		std::snprintf(buf, sizeof(buf), "R%02X", i);
+		auto reg_id = id.WithTags(refs().statistic(), refs().distinct(), refs().distinct(), intern_str(buf));
+		double v = r->GetMaxGauge(std::move(reg_id))->Get();
+		regs[i] = std::isnan(v) ? 0 : static_cast<int>(v);
+	}
+	return regs;
+}
+
+// Parse the [encoding] section into inputs and their expected hash/index/rho.
+struct EncodingVector
+{
+	Input input;
+	uint64_t hash;
+	int index;
+	int rho;
+};
+
+auto parse_encoding(const std::vector<std::string>& lines) -> std::vector<EncodingVector>
+{
+	std::vector<EncodingVector> result;
+	bool in_section = false;
+	for (const auto& line : lines)
+	{
+		if (line.empty() || line[0] == '#') continue;
+		if (line[0] == '[')
+		{
+			in_section = (line == "[encoding]");
+			continue;
+		}
+		if (!in_section) continue;
+		auto f = split(line, '\t');
+		if (f.size() != 5U)
+		{
+			ADD_FAILURE() << "malformed encoding line: " << line;
+			continue;
+		}
+		result.push_back(EncodingVector{decode_input(f[0], f[1]), std::stoull(f[2], nullptr, 16), std::stoi(f[3]),
+		                                 std::stoi(f[4])});
+	}
+	return result;
+}
+
+auto inputs_for_spec(const std::string& spec, const std::vector<EncodingVector>& encoding) -> std::vector<Input>
+{
+	std::vector<Input> inputs;
+	if (spec == "encoding-inputs")
+	{
+		for (const auto& ev : encoding) inputs.push_back(ev.input);
+		return inputs;
+	}
+	auto parts = split(spec, ':');
+	if (parts.size() == 3 && parts[0] == "longs")
+	{
+		int64_t begin = std::stoll(parts[1]);
+		int64_t end = std::stoll(parts[2]);
+		for (int64_t i = begin; i < end; ++i) inputs.push_back(Input{Type::Long, i, {}});
+		return inputs;
+	}
+	throw std::invalid_argument("unknown sketch spec: " + spec);
+}
+
+TEST(DistinctCountSketchVector, EncodingVectors)
+{
+	auto lines = read_lines(kVectorFile);
+	auto encoding = parse_encoding(lines);
+	ASSERT_FALSE(encoding.empty());
+
+	for (const auto& ev : encoding)
+	{
+		// 1. The hash matches spectator-java (xxHash64 over the same bytes).
+		EXPECT_EQ(hash_of(ev.input), ev.hash);
+		// 2. The register derivation matches.
+		EXPECT_EQ(DistinctCountSketch::register_index(ev.hash), ev.index);
+		EXPECT_EQ(DistinctCountSketch::register_rho(ev.hash), ev.rho);
+
+		// 3. Recording the value through the public API populates exactly the expected register.
+		Registry r{GetConfiguration(), spectatord::Logger()};
+		DistinctCountSketch sketch{&r, Id::Of("test")};
+		record_into(&sketch, ev.input);
+		auto regs = read_registers(&r, Id::Of("test"));
+		int populated = 0;
+		for (int i = 0; i < kRegisters; ++i)
+		{
+			if (regs[i] != 0)
+			{
+				++populated;
+				EXPECT_EQ(i, ev.index);
+				EXPECT_EQ(regs[i], ev.rho);
+			}
+		}
+		EXPECT_EQ(populated, 1);
+	}
+}
+
+TEST(DistinctCountSketchVector, SketchVectors)
+{
+	auto lines = read_lines(kVectorFile);
+	auto encoding = parse_encoding(lines);
+
+	bool in_section = false;
+	int checked = 0;
+	for (const auto& line : lines)
+	{
+		if (line.empty() || line[0] == '#') continue;
+		if (line[0] == '[')
+		{
+			in_section = (line == "[sketch]");
+			continue;
+		}
+		if (!in_section) continue;
+
+		auto f = split(line, '\t');
+		ASSERT_EQ(f.size(), 2U) << "malformed sketch line: " << line;
+		auto values = split(f[1], ',');
+		ASSERT_EQ(values.size(), static_cast<size_t>(kRegisters));
+		std::array<int, kRegisters> expected{};
+		for (int i = 0; i < kRegisters; ++i) expected[i] = std::stoi(values[i]);
+
+		Registry r{GetConfiguration(), spectatord::Logger()};
+		DistinctCountSketch sketch{&r, Id::Of("test")};
+		for (const auto& in : inputs_for_spec(f[0], encoding)) record_into(&sketch, in);
+
+		EXPECT_EQ(read_registers(&r, Id::Of("test")), expected) << "sketch mismatch: " << f[0];
+		++checked;
+	}
+	EXPECT_GT(checked, 0);
+}
+
+}  // namespace

--- a/spectator/strings/common_refs.h
+++ b/spectator/strings/common_refs.h
@@ -15,6 +15,7 @@ class Refs final
 	      totalAmount_(intern_str("totalAmount")),
 	      totalSq_(intern_str("totalOfSquares")),
 	      percentile_(intern_str("percentile")),
+	      distinct_(intern_str("distinct")),
 	      max_(intern_str("max")),
 	      statistic_(intern_str("statistic"))
 	{
@@ -27,6 +28,7 @@ class Refs final
 	[[nodiscard]] auto totalAmount() const -> StrRef { return totalAmount_; }
 	[[nodiscard]] auto totalOfSquares() const -> StrRef { return totalSq_; }
 	[[nodiscard]] auto percentile() const -> StrRef { return percentile_; }
+	[[nodiscard]] auto distinct() const -> StrRef { return distinct_; }
 	[[nodiscard]] auto max() const -> StrRef { return max_; }
 	[[nodiscard]] auto statistic() const -> StrRef { return statistic_; }
 
@@ -38,6 +40,7 @@ class Refs final
 	StrRef totalAmount_;
 	StrRef totalSq_;
 	StrRef percentile_;
+	StrRef distinct_;
 	StrRef max_;
 	StrRef statistic_;
 };

--- a/test-resources/distinct_count_sketch_test_vectors.txt
+++ b/test-resources/distinct_count_sketch_test_vectors.txt
@@ -1,0 +1,62 @@
+# Distinct count sketch cross-language test vectors.
+#
+# Generated from the spectator-java reference implementation
+# (DistinctCountSketch). Copy this file to other implementations (e.g.
+# spectatord) and verify they produce the same registers, so that sketches
+# from different clients merge correctly.
+#
+# Hash: xxHash64, seed 0. A long is hashed as its 8-byte little-endian
+# representation; a string as its UTF-8 bytes. Register index = low 6 bits of
+# the hash; rho = 1 + the number of leading zeros in the remaining 58 bits.
+#
+# [encoding]: <type>\t<input>\t<hash>\t<index>\t<rho>
+#   type  = long | str | bytes
+#   input = long: signed decimal; str: UTF-8 literal with \\, \t, \n, \r
+#           escaped; bytes: lowercase hex
+#   hash  = unsigned 64-bit hash as 16 hex digits
+#   index = register index 0..63
+#   rho   = register value 1..59
+#
+# [sketch]: <spec>\t<r0>,<r1>,...,<r63>
+#   spec = encoding-inputs (all inputs above) | longs:<start>:<end>
+#   followed by the 64 register rho values (0 = unused) after recording the
+#   spec's inputs into a single sketch.
+[encoding]
+long	0	34c96acdcadb1bbb	59	3
+long	1	9f29cb17a2a49995	21	1
+long	-1	85d136adb773c6c9	9	1
+long	2	eac73e4044e82db0	48	1
+long	7	0876cd406afde455	21	5
+long	42	b556806fb6d14353	19	1
+long	100	a1df9c5cd454307a	58	1
+long	1000	e53f2d22876c9a49	9	1
+long	1000000	f126194744ecba1e	30	1
+long	123456789	cb7c2941b198004d	13	1
+long	-123456789	6652a701f322f9c0	0	2
+long	3405691582	6b4aca62b5efd3db	27	2
+long	9223372036854775807	ff70cc60366e770c	12	1
+long	-9223372036854775808	3f425eacf01544e0	32	3
+str		ef46db3751d8e999	25	1
+str	a	d24ec4f1a98c6e5b	27	1
+str	ab	65f708ca92d04a61	33	2
+str	abc	44bc2cf5ad770999	25	2
+str	user-12345	64797fca50bfc10c	12	2
+str	192.168.0.1	87f49df2f9f76384	4	1
+str	2001:db8::1	26c33ef1c67e1031	49	3
+str	key=value,other:thing	d799484be9292024	36	1
+str	héllo	3bd06310388ebbe4	36	3
+str	naïve	c07351dc8a26afe6	38	1
+str	世界	6af6be193ab0db0f	15	2
+str	日本語	7179a19f3719f5e1	33	2
+str	😀	9025b8abaae87b80	0	1
+str	👍🏽	637d0995477b428c	12	2
+str	/api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234//api/v1/users/abcd1234/	92c0d26c7c73d1a6	38	1
+bytes		ef46db3751d8e999	25	1
+bytes	00	e934a84adb052768	40	1
+bytes	ff	95634172a60b7544	4	1
+bytes	0001020304050607	884a173614b81b8d	13	1
+bytes	deadbeef	2ff5cfb6af9aaf68	40	3
+bytes	fffefd	622529177845a110	16	2
+[sketch]
+encoding-inputs	2,0,0,0,1,0,0,0,0,1,0,0,2,1,0,2,2,0,0,1,0,5,0,0,0,2,0,2,0,0,1,0,3,2,0,0,3,0,1,0,3,0,0,0,0,0,0,0,1,3,0,0,0,0,0,0,0,0,1,3,0,0,0,0
+longs:0:100000	15,12,13,11,10,10,13,11,11,11,12,10,9,10,13,12,12,10,9,12,11,10,12,9,12,12,11,14,9,16,17,14,11,12,9,12,11,12,13,15,12,20,12,13,10,11,11,11,11,12,11,9,15,14,10,12,14,11,13,10,13,10,9,14


### PR DESCRIPTION
Implements the HyperLogLog distinct count sketch in the C++ client and the spectatord line protocol, matching the spectator-java reference so sketches published by different clients merge correctly.

- DistinctCountSketch decomposes the sketch into 64 per-register max gauges (statistic=distinct, distinct=R##), hashing values with xxHash64 (seed 0): low 6 bits select the register, rho = 1 + the leading-zero run of the remaining bits. Record(long|string|bytes) and RecordHash(uint64).
- Line protocol: 'S:name,tags:<base64>' (spectatord hashes the bytes, the thin-client path) and 's:name,tags:<uint64>' (precomputed hash, for clients that hash locally). Routed through an expiring cache with upkeep expiry and status metrics.
- MaxGauge::Measure now preserves an existing statistic tag (WithDefaultStat) instead of forcing statistic=max, matching Counter and the Java AtlasMaxGauge, so the sketch registers publish correctly.
- Adds a shared cross-language test vector file (copied from spectator-java) and tests verifying the hash, register encoding, and max-register behavior against it, plus protocol-level tests for S/s.